### PR TITLE
TXVEU: MC Event: Fixed a bug that would allow two Ixt to be up at the same time.

### DIFF
--- a/txevu/#Mastruq_Champion.pl
+++ b/txevu/#Mastruq_Champion.pl
@@ -66,6 +66,7 @@ sub EVENT_TIMER {
 		quest::modifynpcstat("special_attacks","ABfHG"); #go inactive
 		quest::moveto(-39,-8,-433,90,1);
 		quest::depopall(297209); #runt
+    quest::depopall(297211); #Ixt_Hsek_Syat
 		quest::stoptimer("reset");
 		$spawn_runt = 1;
 	}


### PR DESCRIPTION
There was a bug that if the MC wasn't killed in 3600 seconds that the MC would reset the event, but not despawn the Ixt.  When the Runt dies when the Event is started again, a second Ixt would spawn, thus allowing cleaver or unfortunate raiders to have two Ixt up at the same time.