### PR TITLE
Made Icefang run

### DIFF
--- a/eastwastes/Icefang.pl
+++ b/eastwastes/Icefang.pl
@@ -8,6 +8,7 @@ sub EVENT_SIGNAL {
     $icefang = 10;
   }
   elsif ($signal == 1161102) {
+    quest::SetRunning(1);
     quest::moveto(1803, -7757, 193);
     $icefang = 25;
   }
@@ -134,6 +135,7 @@ sub EVENT_WAYPOINT_DEPART {
   }
 
   elsif ($icefang == 180) {
+    quest::SetRunning(0);
     quest::moveto(-4404, -3354, 146);
     $icefang = 190;
   }

--- a/thurgadinb/#Dain_Frostreaver_IV.pl
+++ b/thurgadinb/#Dain_Frostreaver_IV.pl
@@ -44,7 +44,7 @@ sub EVENT_SAY {
 sub EVENT_ITEM {
 #Handin for the 9th ring. Needs correct dialogue
   if(plugin::check_handin(\%itemcount, 1500 => 1, 30164 => 1) && ($faction <= 5 || $faction >= 8)) {
-    quest::say("%t, you have done a great service to my people. I had not imagined the treachery had run so deeply within our ranks. Here. Take this ring as your reward. From this day forth, you shall be known as the Hero of the Coldain. Take my Dirk as well, and if you wish to further aid us in our cause, then return it to me.");
+    quest::say("$name, you have done a great service to my people. I had not imagined the treachery had run so deeply within our ranks. Here. Take this ring as your reward. From this day forth, you shall be known as the Hero of the Coldain. Take my Dirk as well, and if you wish to further aid us in our cause, then return it to me.");
     quest::summonitem(30369); #9th ring
     quest::summonitem(1465); #dirk of the Dain
     quest::faction(49,50); #coldain
@@ -55,8 +55,8 @@ sub EVENT_ITEM {
   }
   #Tormax's head
   elsif(plugin::check_handin(\%itemcount, 30516 => 1) && $faction == 1) {
-    quest::say("You have done what no Coldain could do, %t! This is indeed a glorious say in our people's history. In return for your invaluable service I present you with the Tri-plated Golden Hackle Hammer. Its magic is powerful and I am sure it will serve you well.");
-    quest::ze("Let it be know from this day forth that %t and their companions are Heros of the Coldain Kingdom. King Tormax has been slain, it is a time for celebration. Let no tankard go unfilled!");
+    quest::say("You have done what no Coldain could do, $name! This is indeed a glorious say in our people's history. In return for your invaluable service I present you with the Tri-plated Golden Hackle Hammer. Its magic is powerful and I am sure it will serve you well.");
+    quest::ze(2, "Let it be know from this day forth that $name and their companions are Heros of the Coldain Kingdom. King Tormax has been slain, it is a time for celebration. Let no tankard go unfilled!");
     quest::summonitem(30502);
     quest::faction(49,100);
     quest::faction(67,100);
@@ -64,8 +64,8 @@ sub EVENT_ITEM {
   }
 #Dirk handin for the 10th ring
   elsif(plugin::check_handin(\%itemcount, 1465 => 1) && $faction == 1) {
-    quest::say("My good %t, you have served me well. You have flushed out all who sought to oppose me and my people. I am afraid I need to call upon you and your friends one final time. The dissention and treason ran deeper than I had anticipated. Our population has been cleansed, but we lost a full third of our army to the poisonous words of those rebels. In retaliation for your deeds, the Kromrif have made plans to attack us in this, our weakest hour. Can I count on your help outlander?");
-    quest::say("Several of our greatest officers, including a few veterans from the war on Yesterwinter are assembling just outside our city. Gather your army at once and give this parchment and the ninth ring to Sentry Badian. I will remain inside the city with a few of my troops to defend it against any who might penetrate your defense. May Brell be with you, %t.");
+    quest::say("My good $name, you have served me well. You have flushed out all who sought to oppose me and my people. I am afraid I need to call upon you and your friends one final time. The dissention and treason ran deeper than I had anticipated. Our population has been cleansed, but we lost a full third of our army to the poisonous words of those rebels. In retaliation for your deeds, the Kromrif have made plans to attack us in this, our weakest hour. Can I count on your help outlander?");
+    quest::say("Several of our greatest officers, including a few veterans from the war on Yesterwinter are assembling just outside our city. Gather your army at once and give this parchment and the ninth ring to Sentry Badian. I will remain inside the city with a few of my troops to defend it against any who might penetrate your defense. May Brell be with you, $name.");
     quest::summonitem(1567);
   }
   # Runed Coldain Prayer Shawl (7th shawl)

--- a/thurgadinb/#Dain_Frostreaver_IV.pl
+++ b/thurgadinb/#Dain_Frostreaver_IV.pl
@@ -65,7 +65,7 @@ sub EVENT_ITEM {
 #Dirk handin for the 10th ring
   elsif(plugin::check_handin(\%itemcount, 1465 => 1) && $faction == 1) {
     quest::say("My good %t, you have served me well. You have flushed out all who sought to oppose me and my people. I am afraid I need to call upon you and your friends one final time. The dissention and treason ran deeper than I had anticipated. Our population has been cleansed, but we lost a full third of our army to the poisonous words of those rebels. In retaliation for your deeds, the Kromrif have made plans to attack us in this, our weakest hour. Can I count on your help outlander?");
-    quest::summonitem(1465);
+    quest::summonitem(1567);
   }
   # Runed Coldain Prayer Shawl (7th shawl)
   elsif(plugin::check_handin(\%itemcount, 1199 => 1) || plugin::check_handin(\%itemcount, 8895 => 1)) {

--- a/thurgadinb/#Dain_Frostreaver_IV.pl
+++ b/thurgadinb/#Dain_Frostreaver_IV.pl
@@ -65,6 +65,7 @@ sub EVENT_ITEM {
 #Dirk handin for the 10th ring
   elsif(plugin::check_handin(\%itemcount, 1465 => 1) && $faction == 1) {
     quest::say("My good %t, you have served me well. You have flushed out all who sought to oppose me and my people. I am afraid I need to call upon you and your friends one final time. The dissention and treason ran deeper than I had anticipated. Our population has been cleansed, but we lost a full third of our army to the poisonous words of those rebels. In retaliation for your deeds, the Kromrif have made plans to attack us in this, our weakest hour. Can I count on your help outlander?");
+    quest::say("Several of our greatest officers, including a few veterans from the war on Yesterwinter are assembling just outside our city. Gather your army at once and give this parchment and the ninth ring to Sentry Badian. I will remain inside the city with a few of my troops to defend it against any who might penetrate your defense. May Brell be with you, %t.");
     quest::summonitem(1567);
   }
   # Runed Coldain Prayer Shawl (7th shawl)

--- a/thurgadinb/#Dain_Frostreaver_IV.pl
+++ b/thurgadinb/#Dain_Frostreaver_IV.pl
@@ -38,7 +38,13 @@ sub EVENT_SAY {
   if ($text=~/factor/i && plugin::check_hasitem($client, 8898)) {
     # Approved Issue Kit (id:8898)
     quest::say("I fear that spies lurk in every corner. You may need to help the General reach the gnomish camp if the Kromrif have gotten word of our efforts. You should call on any allies that you have to assist in case they ambush you. Brell bless you $name, good luck.");
-  } 
+  }
+  if ($text=~/count/i && plugin::check_hasitem($client, 1465)) {
+    if ($faction <= 5 || $faction >= 8) {
+      quest::say("Several of our greatest officers, including a few veterans from the war of Yesterwinter are assembling just outside our city. Gather your army at once and give this parchment and the ninth ring to Sentry Badian. I will remain inside the city with a few of my troops to defend it against any who might penetrate your defense. May Brell be with you, $name.");
+	  quest::summonitem(1567); #Declaration of War
+    }
+  }
 }
 
 sub EVENT_ITEM {
@@ -65,8 +71,7 @@ sub EVENT_ITEM {
 #Dirk handin for the 10th ring
   elsif(plugin::check_handin(\%itemcount, 1465 => 1) && $faction == 1) {
     quest::say("My good $name, you have served me well. You have flushed out all who sought to oppose me and my people. I am afraid I need to call upon you and your friends one final time. The dissention and treason ran deeper than I had anticipated. Our population has been cleansed, but we lost a full third of our army to the poisonous words of those rebels. In retaliation for your deeds, the Kromrif have made plans to attack us in this, our weakest hour. Can I count on your help outlander?");
-    quest::say("Several of our greatest officers, including a few veterans from the war on Yesterwinter are assembling just outside our city. Gather your army at once and give this parchment and the ninth ring to Sentry Badian. I will remain inside the city with a few of my troops to defend it against any who might penetrate your defense. May Brell be with you, $name.");
-    quest::summonitem(1567);
+    quest::summonitem(1465);
   }
   # Runed Coldain Prayer Shawl (7th shawl)
   elsif(plugin::check_handin(\%itemcount, 1199 => 1) || plugin::check_handin(\%itemcount, 8895 => 1)) {


### PR DESCRIPTION
Once activated Icefang is supposed to run at SoW speed.  Updated quest to SetRunning(1) at the beginning of the escort, but set it back to default when the camp spawns so he doesn't suicide into it before the player(s) can agro the camp.  Ideally Korrigain would buff Icefang before he takes off running, but i'm not exactly sure what buffs Korrigain is supposed to cast. (for a future update I suppose).