### PR TITLE
* Dialog and truespirit faction fixes per live.

### DIFF
--- a/butcher/Kandin_Firepot.lua
+++ b/butcher/Kandin_Firepot.lua
@@ -18,7 +18,7 @@ function event_trade(e)
 	if(item_lib.check_turn_in(e.trade, {item1 = 18169})) then
 		e.self:Say("Brother! I have one of those. He's great, but he's dead. His name was Gabstik and he was a really powerful wizard. I still have one of his greatest possesions! You look like you could use it. I've added another thing to my shopping list. I require a dry brittle skin that I can mold or a rare oil found in the planes that I can soak the fuse in. Get me one of these things and I'll trade it for my bother's stick.");
 		e.other:Ding();
-		e.other:Faction(342, 30); --Truespirit
+		e.other:Faction(342, 10); --Truespirit
 		eq.set_global("wizepicK","1",0,"F");
 	elseif(qglobals["wizepicK"] ~= nil) then
 		if(item_lib.check_turn_in(e.trade, {item1 = 14349})) then

--- a/erudnext/Camin.lua
+++ b/erudnext/Camin.lua
@@ -16,15 +16,16 @@ function event_trade(e)
 		e.other:Ding();
 		e.other:AddEXP(500);
 	elseif(item_lib.check_turn_in(e.trade, {item1 = 14330}) and qglobals["wizepic"] == "1") then
-		e.self:Say("So you have met Solomen, eh? He is a man with a wealth of knowledge. It is good to hear he is well.");
+		e.self:Say("Camin says 'Very interesting... I've seen this work before. Yes, yes! It's the work of Arantir Karondor! Give this back to the person you got it from. Maybe he will have a clue to Arantir's location.'");
 		e.other:SummonItem(14331);
-		e.other:Faction(342,30,0); -- Truespirit
+		e.other:Faction(342,10,0); -- Truespirit
 		e.other:Ding();
 		e.other:AddEXP(10000);
 		eq.delete_global("wizepic");
 	elseif(item_lib.check_turn_in(e.trade, {platinum = 1000})) then
 		e.self:Say("Good, good, you show a willingness to learn of this with your offer. What I can tell you is that Solusek Ro had four followers who had shown exceptional aptitude in the arts of wizardry. Solusek Ro himself tutored them. He considered them to be like his own children. I know of one who still exists. He goes by the name of Arantir Karondor. He used to specialize in the storing of magic into physical objects. Arantir has been hiding for many, many years and will most assuredly be going by another name, so keep your eyes open. Anyway, be off, I need to continue my research. Return to me if you ever find Arantir Karondor.");
 		e.other:Ding();
+		e.other:Faction(342,10,0); -- Truespirit
 		e.other:AddEXP(500);
 		eq.set_global("wizepic","1",0,"D30");
 	end

--- a/felwithea/Challice.lua
+++ b/felwithea/Challice.lua
@@ -5,11 +5,9 @@ function event_say(e)
 end
 
 function event_trade(e)
-	local qglobals = eq.get_qglobals(e.other);
 	local item_lib = require("items");
 
-	if(qglobals["wiz_epic_challicering"] == nil and item_lib.check_turn_in(e.trade, {item1 = 14334})) then -- Note handin:
-		eq.set_global("wiz_epic_challicering","1",5,"F");
+    if(item_lib.check_turn_in(e.trade, {item1 = 14334})) then -- Note handin:
 		e.self:Say("Oh yes? Arantir? What a fool he was! the man gave me everything, but for all his intelligence, he could never understand why I was truly with him. It was for his power; he could do anything. But when he mysteriously lost it, he became just another toy. I never loved him. Return this ring to him. He will understand that I have no desire to see him again.");
 		e.other:Ding();
 		e.other:Faction(342, 10,0); --Truespirit

--- a/felwithea/Challice.lua
+++ b/felwithea/Challice.lua
@@ -5,12 +5,14 @@ function event_say(e)
 end
 
 function event_trade(e)
+	local qglobals = eq.get_qglobals(e.other);
 	local item_lib = require("items");
 
-	if(item_lib.check_turn_in(e.trade, {item1 = 14334})) then -- Note handin:
+	if(qglobals["wiz_epic_challicering"] == nil and item_lib.check_turn_in(e.trade, {item1 = 14334})) then -- Note handin:
+		eq.set_global("wiz_epic_challicering","1",5,"F");
 		e.self:Say("Oh yes? Arantir? What a fool he was! the man gave me everything, but for all his intelligence, he could never understand why I was truly with him. It was for his power; he could do anything. But when he mysteriously lost it, he became just another toy. I never loved him. Return this ring to him. He will understand that I have no desire to see him again.");
 		e.other:Ding();
-		e.other:Faction(342, 30,0); --Truespirit
+		e.other:Faction(342, 10,0); --Truespirit
 		e.other:AddEXP(100000);
 		e.other:SummonItem(14335);
 	end

--- a/halas/Arantir_Karondor.lua
+++ b/halas/Arantir_Karondor.lua
@@ -10,7 +10,7 @@ function event_say(e)
 			e.self:Say("Ah yes, you again. Do you have the items? Give me the three you possess and I'll combine them with my own.");
 		elseif(qglobals["wizepicA"] == "1") then
 			e.self:Say("Ah, but it pains my heart to see this. How I could love a women like that is beyond me. And yet, I still do love her. It was on the day I was to ask her to marry me that I lost my powers. When I was about to cast my greatest spell to prove my love to her, my magic failed. She ran out on me that day. But enough of me, do you wish to hear my story?");
-		elseif(qglobals["wiz_epic_challicering"] == nil) then
+		else
 			e.self:Say("Before I tell you anything, I require you to help me. Seek a woman named Challice. Give her this ring and then return to me.");
 			e.other:SummonItem(14334);
 		end

--- a/halas/Arantir_Karondor.lua
+++ b/halas/Arantir_Karondor.lua
@@ -10,7 +10,7 @@ function event_say(e)
 			e.self:Say("Ah yes, you again. Do you have the items? Give me the three you possess and I'll combine them with my own.");
 		elseif(qglobals["wizepicA"] == "1") then
 			e.self:Say("Ah, but it pains my heart to see this. How I could love a women like that is beyond me. And yet, I still do love her. It was on the day I was to ask her to marry me that I lost my powers. When I was about to cast my greatest spell to prove my love to her, my magic failed. She ran out on me that day. But enough of me, do you wish to hear my story?");
-		else
+		elseif(qglobals["wiz_epic_challicering"] == nil) then
 			e.self:Say("Before I tell you anything, I require you to help me. Seek a woman named Challice. Give her this ring and then return to me.");
 			e.other:SummonItem(14334);
 		end
@@ -23,7 +23,6 @@ function event_say(e)
 	elseif(e.message:findi("the gnome") and e.other:Class() == "Wizard") then
 		e.self:Say("Ah, the gnome I know very little about. I know he was small and crafty, and that he had a brother. His brother's craft was that of making fireworks, and he was the unfortunate victim of one of his own experiments. His firework exploded, leaving his mind diminished in capacity, even for a gnome. I remember others calling him 'Old Stewpot' in jest. I do not know if this is his birth name, but it may help you to locate him. I hear he also stays close to water because of the explosion. You never know when another gnomish invention will go awry. Give him this letter to help motivate him to remember.");
 		e.other:SummonItem(18169);
-		e.other:Faction(342, 30,0); 									--Truespirit
 		eq.depop();
 	end
 end
@@ -44,6 +43,7 @@ function event_trade(e)
 			e.self:Say("Here, this pack contains all of our items. You will never be able to open it again, so you must deliver the pack, intact, to Solomen. He will then reward you. Now that I have helped you, leave me in peace.");
 			e.other:Ding();
 			e.other:SummonItem(14340);
+			e.other:Faction(342, 30,0); 									--Truespirit
 			eq.delete_global("wizepicA");
 		end
 	end

--- a/soltemple/Solomen.pl
+++ b/soltemple/Solomen.pl
@@ -17,6 +17,7 @@ sub EVENT_ITEM {
 	if($itemcount{14340} == 1){
 		quest::say("You actually did it! I never would have thought that anyone could have truly followed this path. This is a tribute to your intelligence and patience. Here, take this staff and know that you have made Solusek Ro and all the wizards of the world proud this day.");
 		quest::summonitem(14341);
+		quest::faction(342, -100); #truespirit, resets the +100 in gains from quest start up to this point.
 	} else {
 		quest::say("I don't need this.");
 		if($item1 > 0){quest::summonitem("$item1");} 


### PR DESCRIPTION
* Dialog and truespirit faction fixes to match live for Wizard Epic 1.0
* Fixed an exploit where you could increase your truespirit faction by repeating a sequence between Arantir and Challice.