### PR TITLE
Update Camin.lua

### DIFF
--- a/erudnext/Camin.lua
+++ b/erudnext/Camin.lua
@@ -27,6 +27,7 @@ function event_trade(e)
 		e.other:Ding();
 		e.other:Faction(342,10,0); -- Truespirit
 		e.other:AddEXP(500);
+		eq.delete_global("wizepicA"); -- Delete this global so if a player deletes Arantir's ring they can restart epic again. The only known way to delete this global is to finish the epic. Delete it here instead.
 		eq.set_global("wizepic","1",0,"D30");
 	end
 	item_lib.return_items(e.self, e.other, e.trade);


### PR DESCRIPTION
Add a workaround for destroying Arantir's Ring by accident, or losing it in general.
The only known method of resetting the global is by completing the epic causing you in an infinite loop never being able to receive the ring again. This will delete the global after handing him 1000platinum allowing you to hail Dargon to turn into Arantir so you can hail for new ring.