### PR TITLE
Fix Daignal

### DIFF
--- a/dranik/#Daignal_the_Revered.lua
+++ b/dranik/#Daignal_the_Revered.lua
@@ -1,4 +1,11 @@
 local event_started=0;
+
+
+function event_spawn(e)
+	event_started=0;
+end
+
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
 	if (event_started==1) then


### PR DESCRIPTION
After completing an epic correctly - Diagnal will respawn if #repop force and hail will immediately cause him to FD/depop_w_timer.
Adding in the event_started=0 will cause him to always repop with event_started set to 0. Tested on local server.