### PR TITLE
Change double equals to single

### DIFF
--- a/butcher/#Kanthuk_Ogrebane.lua
+++ b/butcher/#Kanthuk_Ogrebane.lua
@@ -36,7 +36,7 @@ end
 function event_trade(e)
 	local item_lib = require("items");
 	
-	if(item_lib.check_turn_in(e.trade, {item1 == 2416})) then
+	if(item_lib.check_turn_in(e.trade, {item1 = 2416})) then
 		e.other:Ding();
 		e.self:Say("Ahh, I see you have spoken to Ryshon. You seem tired from your long journey. Sit with me as I tell you a tale. A tale about a true friend of mine, a great man known as [Amstaf Trunolis].");
 		eq.set_global("Kanthuk","ghoul",0,"D30");

--- a/butcher/Guard_Haldin.lua
+++ b/butcher/Guard_Haldin.lua
@@ -1,6 +1,6 @@
 function event_trade(e)
 	local item_lib = require("items");
-	if(item_lib.check_turn_in(e.trade, {item1 == 18905})) then
+	if(item_lib.check_turn_in(e.trade, {item1 = 18905})) then
 		e.self:Say("The slaves...thank you! Here, this will help you slaughter those foul orcs!");
 		e.other:AddEXP(30000);
 		e.other:Ding();


### PR DESCRIPTION
It looks like the '==' causes the check_turn_in to always be true. Changed it to '=' to match other quests. 