### PR TITLE
Urako's Big Mistake (Bregna's is Neriak Era)

### DIFF
--- a/grobb/Basher_Avisk.lua
+++ b/grobb/Basher_Avisk.lua
@@ -1,0 +1,8 @@
+function event_say(e)
+	if(e.message:findi("hail")) then
+		e.self:Say("Ranjor tell shaddernites to gets rids of spore guardian. Ha! Gud.");
+	elseif(e.message:findi("where the minstrel")) then
+		e.self:Say("Dere stewpid skeleton singing by Basher Ganbaku. His post be up high.");
+		eq.unique_spawn(52119,0,0,-182,313,26.7,459);	
+	end
+end

--- a/grobb/Basher_Nanrum.lua
+++ b/grobb/Basher_Nanrum.lua
@@ -1,12 +1,16 @@
 -- Quest Name: A job for Nanrum
 -- Author: BWStripes
 -- Converted to .lua by Speedz
+-- Added support for Urako's Big Mistake
 
 function event_say(e)
 	if(e.message:findi("hail")) then
-		e.self:Say("Peh! What am you wanted?! I am Basher Nanrum. You? " .. e.other:GetName() .. " ? Heh, you look for works? Hmm, me tinks you too weakling for [" .. eq.say_link("job",false,"job") .. "] me need done. Hmm.. You might do, mebbe.",e.other:GetName());
+		e.self:Say("Peh! What am you wanted?! I am Basher Nanrum. You? " .. e.other:GetName() .. "? Heh, you look for works? Hmm, me tinks you too weakling for [" .. eq.say_link("job",false,"job") .. "] me need done. Hmm.. You might do, mebbe.");
 	elseif(e.message:findi("job")) then
 		e.self:Say("Me in charge of making torches for basher patrols. But Nanrum is much too mighty for such stupid job and Nanrum get idea. Dem fire bugses in da desert - dem eyes glowed. And dem don't burneded like torches. If " .. e.other:GetName() .. " getted Nanrum three fire beetle eyes me would giveded " .. e.other:GetName() .. " a shiny thingie dat you wanteded. Go ahed, " .. e.other:GetName() .. " , an' get me da eyes.");
+	elseif(e.message:findi("where is the skeleton")) then
+		e.self:Say("Yeah!  Me see dat bone man.  He over by da Cleaver.  He tink he a butcher or sumting!");
+		eq.unique_spawn(52118,0,0,-459,359,10,0);	
 	end
 end
 

--- a/grobb/Bregna.lua
+++ b/grobb/Bregna.lua
@@ -5,7 +5,7 @@
 
 function event_say(e)
 	if(e.message:findi("hail")) then
-		e.self:Say("Hail, Reveree, are ya a follower ob Innoruuk?  I hopes so.  We needs many ta spread His Hate.  None be as bicious as be dem dat follow Him.  We do brings fear and hate ta all dat does sees us.  Dis is well.  He likes it.  Can ya [help]?");
+		e.self:Say("Hail, " .. e.other:GetName() .. " , are ya a follower ob Innoruuk?  I hopes so.  We needs many ta spread His Hate.  None be as bicious as be dem dat follow Him.  We do brings fear and hate ta all dat does sees us.  Dis is well.  He likes it.  Can ya [help]?");
 	elseif (e.message:findi("help")) then
 		e.self:Say("'Me hears orcs nearby are trubble.  Da werd frum Neriak is dey wants us ta kills dem before dey organize.  Dark elf say ta looks for Deathfist Clan.  Say dey called cen-tu-ri-ons.  Dey try ta gets big orc army.  Shows me ya can strike fear and hate inta dem orcs... dey needs be more scared a us den dem humies.  Brings me a Deathfist slashed belt.");
 	end

--- a/grobb/Bregna.lua
+++ b/grobb/Bregna.lua
@@ -1,31 +1,28 @@
--- Bregna's Big Mistake
 -- Aid Garuuk
 -- Converted to .lua by Speedz
 -- added saylink by robregen
+-- removed Bregna's Big Mistake (See Urako) - added More Help for Innoruuk (noudess)
 
 function event_say(e)
 	if(e.message:findi("hail")) then
-		e.self:Say("Me says hi to you. What you want from me? Oh!! Me shaman trainer. You must be shaman. Are you [" .. eq.say_link("shaman Darkone",false,"shaman Darkone") .. "]?");
-	elseif(e.message:findi("shaman darkone")) then
-		e.self:Say("You choose rite if you bes a shaman. We's da best. You remember ta not get in Kaglari way. She get mad berry easy. She gets berry mad at Bregna if she finds out me make [" .. eq.say_link("big mistake",false,"big mistake") .. "].");
-	elseif(e.message:findi("big mistake")) then
-		e.self:Say("Kaglari make me do the tasks for her. She tolds me to take crate of speshal poshuns to sumwun in Nektoolos forust. But I make mistake. I fall asleep under da trees becuz I was so tired. I wake up and poshuns are gone! Sumwun take the poshuns frum me. Dey leave dis note wit me. Me tinks dey play trick on me. Me tinks it be da stinkin' Halflings. Me needs ta gets dem back before Kaglari find out. I need sumwun to help me [" .. eq.say_link("find da poshuns",false,"find da poshuns") .. "].");
-	elseif(e.message:findi("find da poshuns")) then
-		e.self:Say("Take dis as it be all me know.");
-		e.other:Ding();
-		e.other:SummonItem(18651); -- Item: Note to the Troll
+		e.self:Say("Hail, Reveree, are ya a follower ob Innoruuk?  I hopes so.  We needs many ta spread His Hate.  None be as bicious as be dem dat follow Him.  We do brings fear and hate ta all dat does sees us.  Dis is well.  He likes it.  Can ya [help]?");
+	elseif (e.message:findi("help")) then
+		e.self:Say("'Me hears orcs nearby are trubble.  Da werd frum Neriak is dey wants us ta kills dem before dey organize.  Dark elf say ta looks for Deathfist Clan.  Say dey called cen-tu-ri-ons.  Dey try ta gets big orc army.  Shows me ya can strike fear and hate inta dem orcs... dey needs be more scared a us den dem humies.  Brings me a Deathfist slashed belt.");
 	end
 end
 
 function event_trade(e)
 	local item_lib = require("items");
-	if (item_lib.check_turn_in(e.trade, {item1 = 13984})) then -- Bregna's Big Mistake
-		e.self:Say("Now Kaglari won't be mad at Bregna.");
-		e.other:SummonItem(12212); -- Item: Kaglari Mana Doll
+	if (item_lib.check_turn_in(e.trade, {item1 = 13916})) then -- More help for Innoruuk
+		e.self:Say("Good job. Dat help lerns um. Takes dis ta help ya lerns how ta do more hateful tings. Ya gots a good starts fer Him ta be prouds a ya.");
+		e.other:SummonItem(15272); -- Spell: Spirit Pouch
+		e.other:Faction(251,-1,0); -- -Frogloks of Guk
+		e.other:Faction(237,5,0);  -- +Dark Ones
+		e.other:Faction(308,1,0);  -- +Shadowknights of Night Keep
 		e.other:Ding();
 		e.other:AddEXP(100);
 	elseif (item_lib.check_turn_in(e.trade, {item1 = 26632, item2 = 26640, item3 = 29921, item4 = 26662})) then -- Aid Garuuk
-		e.self:Say("Ere. take dis back to Garuuk, K.");
+		e.self:Say("Dis am gud. I see you've been talkin' to Garuuk. Methanks you fer da help. Take dis note back ta Garuuk so he knows you helped me. Tanks again!");
 		e.other:SummonItem(28740); -- Item: Troll Receipt
 		e.other:Ding();
 		e.other:AddEXP(10000);

--- a/grobb/Urako.lua
+++ b/grobb/Urako.lua
@@ -29,8 +29,8 @@ function event_trade(e)
 	if (item_lib.check_turn_in(e.trade, {item1 = 12213, item2 = 12214, item3 = 12215, item4 = 12216})) then -- all the skeleton heads
 		e.self:Say("Tank you. You saved me neck. Kaglari not learn me mistake now. Me give you a [Kaglari mana doll].");
 		e.other:SummonItem(12212);
-	    e.other:Ding();
-        e.other:AddEXP(145); -- A guess
+		e.other:Ding();
+		e.other:AddEXP(145); -- A guess
 		e.other:Faction(251,-1,0); -- -Frogloks of Guk
 		e.other:Faction(237,10,0);  -- +Dark Ones
 		e.other:Faction(308,2,0);  -- +Shadowknights of Night Keep

--- a/grobb/Urako.lua
+++ b/grobb/Urako.lua
@@ -1,16 +1,38 @@
 -- Converted to .lua by Speedz
 -- added saylink by robregen
+-- added faction checks as well as the turnin for Urako's Big Mistake
 
 function event_say(e)
+	local pfaction = e.other:GetFaction(e.self);
+
 	if(e.message:findi("Hail")) then
 		e.self:Say("Me says hi to you.  What you want from me?  Oh!!  Me shaman trainer.  You must be shaman.  Are you [" .. eq.say_link("shaman Darkone",false,"shaman Darkone") .. "]?");
+	elseif (pfaction > 5) then
+		e.self:Say("You die! Me Darkone!  We no frend to you.  You run now!");
+	elseif (pfaction > 4) then
+		e.self:Say("Darkones no hates you, buts you not helps us enuff.");
 	elseif(e.message:findi("shaman darkone")) then
 		e.self:Say("You choose rite if you bes a shaman.  Wes da best.  You remember ta not get in Kaglari way.  He get mad berry easy.  He gets berry mad at Urako if he finds out me make [" .. eq.say_link("big mistake",false,"big mistake") .. "].");
 	elseif(e.message:findi("big mistake")) then
 		e.self:Say("Kaglari makes Urako cleans his kwarters.  He says nots to open closet.  Me make mistake and opens his closet and out comes da skeletons.  Dey runs out into Grobb.  Me needs ta gets dem back before Kaglari finds out.  Me needs sumwun to [" .. eq.say_link("collect Kaglari skeletons",false,"collect Kaglari skeletons") .. "].");
 	elseif(e.message:findi("collect kaglari skeletons")) then
 		e.self:Say("Tank you!!  Dere is fours of dem.  You can finds dem here in Grobb.  I no tink dey will want to come homes to Kaglari's closet.  You ask dem to [" .. eq.say_link("come back to the closet",false,"come back to the closet") .. "] and see whut dey say.  If you gets dem back me promise to gives you a [" .. eq.say_link("Kaglari mana doll",false,"Kaglari mana doll") .. "].");
+		eq.unique_spawn(52056,0,0,-266,153,11,0);	
 	elseif(e.message:findi("kaglari mana doll")) then
 		e.self:Say("Kaglari catch many humans.  He pull spirit from dem and force into dolls.  Now deir spirit give shaman extra mana.  Dey good power source.  Now humans good for someting.  Da mana dolls only for shaman power.");
+	end
+end
+
+function event_trade(e)
+	local item_lib = require("items");
+
+	if (item_lib.check_turn_in(e.trade, {item1 = 12213, item2 = 12214, item3 = 12215, item4 = 12216})) then -- all the skeleton heads
+		e.self:Say("Tank you. You saved me neck. Kaglari not learn me mistake now. Me give you a [Kaglari mana doll].");
+		e.other:SummonItem(12212);
+	    e.other:Ding();
+        e.other:AddEXP(145); -- A guess
+		e.other:Faction(251,-1,0); -- -Frogloks of Guk
+		e.other:Faction(237,10,0);  -- +Dark Ones
+		e.other:Faction(308,2,0);  -- +Shadowknights of Night Keep
 	end
 end

--- a/grobb/a_skeleton.lua
+++ b/grobb/a_skeleton.lua
@@ -1,7 +1,7 @@
 -- Created by noudess
 
 function event_say(e)
-	local pfaction = e.other:GetFaction(e.self)-1;
+	local pfaction = e.other:GetFaction(e.self);
 
 	if(e.message:findi("Hail")) then
 		if (e.self:GetNPCTypeID() == 52056) then

--- a/grobb/a_skeleton.lua
+++ b/grobb/a_skeleton.lua
@@ -1,0 +1,48 @@
+-- Created by noudess
+
+function event_say(e)
+	local pfaction = e.other:GetFaction(e.self)-1;
+
+	if(e.message:findi("Hail")) then
+		if (e.self:GetNPCTypeID() == 52056) then
+			e.self:Say("Sorry.  Nothing t' sell at this time.  Maybe later.  Good day.");
+		elseif (e.self:GetNPCTypeID() == 52118) then
+			e.self:Say("Step right up! I am the best butcher you have ever seen.  Well, are you the next to be fileted?");
+		elseif (e.self:GetNPCTypeID() == 52119) then
+			e.self:Say("Here I stand high and above, a minstrel supreme, my words offer love. Love between all, troll and ogre alike. I sing to all, except Tabaz, so take a hike!");
+		end
+		
+	elseif(e.message:findi("come back to the closet")) then
+		if (pfaction > 5) then
+			e.self:Say("I would like to assist you, but my masters say you are no friend of the Darkones and would rather see you dead.");
+		elseif (pfaction > 4) then
+			e.self:Say("You're going to have to prove yourself a stronger aid to my masters, the Darkones.");
+		else
+			if (e.self:GetNPCTypeID() == 52056) then
+				e.self:Say("Back to the closet?!  I just got out.  I would go back if I had a pair of oven mittens.");
+			elseif (e.self:GetNPCTypeID() == 52118) then
+				e.self:Say("Darn!  I was just starting to have fun.  Tell you what, you find me a nice ogre butcher apron and I will gladly go back to my cramped quarters.");
+			elseif (e.self:GetNPCTypeID() == 52119) then
+				e.self:Say("Back to the closet?! Not until I can get an instrument. You get me... hmm, I know. Get me a lizardman scout fife. Not just one, but four. Then my friends can also play along with me. Do this and I promise you I shall return.");
+			end
+		end
+	end
+end
+
+function event_trade(e)
+	local item_lib = require("items");
+
+	if (e.self:GetNPCTypeID() == 52056 and item_lib.check_turn_in(e.trade, {item1 = 12211})) then -- Mittens
+		e.self:Say("Ahh! Oven mittens! Kinda' large, don't you think?! Oh well, now I can bake all I want without burning my hands. OKAY! Lets go. I overheard some basher named Nanrum saying he spotted my friend, the butcher. You should ask him [where the skeleton] is.");
+		e.other:SummonItem(12213);
+		eq.depop();
+	elseif (e.self:GetNPCTypeID() == 52118 and item_lib.check_turn_in(e.trade, {item1 = 12217})) then -- butcher arpron
+		e.self:Say("Great! Thanks a lot, pal. Lets get moving. I hear my bonehead roomie called the Captain was spotted by Basher Sklama. Go ask [where the Captain] is.");
+		e.other:SummonItem(12214);
+		eq.depop();
+	elseif (e.self:GetNPCTypeID() == 52119 and item_lib.check_turn_in(e.trade, {item1 = 12198, item2 = 12198, item3 = 12198, item4 = 12198})) then -- fifes
+		e.self:Say("All right! I was kinda hoping the lizards would finish you off and I could stay free, but a deal is a deal. Let's go.");
+		e.other:SummonItem(12216);
+		eq.depop();
+	end
+end

--- a/innothuleb/Basher_Sklama.lua
+++ b/innothuleb/Basher_Sklama.lua
@@ -1,6 +1,9 @@
 function event_say(e)
 	if(e.message:findi("hail")) then
 		e.self:Say("Me hear dat dere are humans, elves and other weaklings hunting in da swamp.");
+	elseif(e.message:findi("where the captain")) then
+		e.self:Say("You speak of da skeleton. He belong to Kaglari. He in dis swamp on little island.");
+		eq.unique_spawn(46108,0,0,-6.7,-1422,-12.25,0);	
 	end
 end
 

--- a/innothuleb/a_skeleton.lua
+++ b/innothuleb/a_skeleton.lua
@@ -1,0 +1,27 @@
+-- Created by noudess
+
+function event_say(e)
+	local pfaction = e.other:GetFaction(e.self)-1;
+
+	if(e.message:findi("Hail")) then
+		e.self:Say("Avast, matey! Captain Bones here. This here island is mine! Raise anchor and ship out");
+	elseif(e.message:findi("come back to the closet")) then
+		if (pfaction > 5) then
+			e.self:Say("I would like to assist you, but my masters say you are no friend of the Darkones and would rather see you dead.");
+		elseif (pfaction > 4) then
+			e.self:Say("You're going to have to prove yourself a stronger aid to my masters, the Darkones.");
+		else
+			e.self:Say("I wish I could be leaving this isle of the damned, alas, me boat has gone to Prexus' locker. I'll not be leavin' here until I get meself another ship.");
+		end
+	end
+end
+
+function event_trade(e)
+	local item_lib = require("items");
+
+	if (item_lib.check_turn_in(e.trade, {item1 = 12218})) then -- ship in a bottle
+		e.self:Say("Aye, matey! Ye found me another vessel with which to sail the seven seas? Let's be shoving off then! Come on, hop aboard, swabby! Be sure to pick up the minstrel. His hide was last seen by Basher Avisk. Only he be knowin' [where the minstrel ] be.");
+		e.other:SummonItem(12215);
+		eq.depop();
+	end
+end


### PR DESCRIPTION
These changes implement Urako's big mistake.

However, to be usable by PEQ someone will have to:

- modify the faction on npc #52056 (a_skeleton in grobb) to be on DarkOnes faction
- add (3) new npcs (copies of #52056).  Two new ones in grobb and one new one in Innothule.
- These npcs are copies of 52056 but need to be diferentiatable as they all have diff text and actions, all named "a_skeleton".    Mine are referenced in the quest files included.  46108 is in Innothule.  52118 and 52119 are in Grobb.  52119 is modified to be a  bard.  Not sure if your db has these ids available.

I believe if someone does these edits to peqdb - than this will implement this quest for you.  It is fuilkly tested locally.