### PR TITLE
Update Jinkus_Felligan.lua

### DIFF
--- a/halas/Jinkus_Felligan.lua
+++ b/halas/Jinkus_Felligan.lua
@@ -16,7 +16,7 @@ function event_trade(e)
 		e.self:Say("Good, now you must take this wanted poster i made to Guard Eracon Krengon in Southern Qeynos. Bring me back the Most Wanted List...");
 		e.other:SummonItem(12620);													--Wanted Poster
 		e.other:Ding();
-	elseif(item_lib.check_turn_in(e.trade, {item1 = 12622, item2 = 12619})) then	--List of Qeynos Most Wanted
+	elseif(item_lib.check_turn_in(e.trade, {item1 = 12622})) then	--List of Qeynos Most Wanted
 		e.self:Say("Fantastic, Fantastic... Here you have more than proven your right to wear this. Use it wisely...");
 		e.other:SummonItem(1376); 													--Initiate Symbol of the Tribunal
 		e.other:Faction(5002,2);  													--Banker


### PR DESCRIPTION
There is no reason to hand Jinkus the Vial of Dakura Ink back on the final hand-in.  He only requests the List of Qeynos Most Wanted.  Removed Dakura Ink from final hand-in. Quest should be working correctly now.