### PR TITLE
a_protector_of_growth auto-aggro script

### DIFF
--- a/growthplane/a_protector_of_growth.pl
+++ b/growthplane/a_protector_of_growth.pl
@@ -1,0 +1,46 @@
+# a_protector_of_growth #127003 
+
+sub ScanForKOS() {
+    # Wait until there are at least 8 PCs in zone
+    my @clist = $entity_list->GetClientList();
+    return if (scalar(@clist) < 8);
+
+    # Find visible non-GM enemies
+    my @cenemies;
+    foreach $pc (@clist) {
+        next if $pc->Admin() || $pc->GetFeigned() || $pc->IsInvisible($npc);
+
+        $pcfaction = $pc->GetCharacterFactionLevel(226); # Clerics of Tunare
+        push(@cenemies, $pc) if ($pcfaction < -750);
+    }
+
+    # Wait until there are at least 3 enemies in zone
+    return if (scalar(@cenemies) < 3);
+    
+    # Aggro a random enemy PC
+    my $pctarget = $cenemies[rand @cenemies];
+    if ($pctarget) {
+        quest::ze(15, "You hear a horn sound in the distance.");
+        quest::attack($pctarget->GetName());
+        quest::stoptimer("scanforkos");
+    }
+}
+
+sub EVENT_SPAWN {
+    quest::settimer("scanforkos", 120);
+}
+
+sub EVENT_TIMER {
+    if ($timer eq "scanforkos") {
+        ScanForKOS();
+    } 
+}
+
+sub EVENT_COMBAT {
+    if ($combat_state == 0) {
+        quest::settimer("scanforkos", 120);
+        ScanForKOS();
+    }
+}
+
+# END a_protector_of_growth #127003 

--- a/growthplane/a_protector_of_growth.pl
+++ b/growthplane/a_protector_of_growth.pl
@@ -1,10 +1,6 @@
 # a_protector_of_growth #127003 
 
 sub ScanForKOS() {
-    # Wait until there are at least 8 PCs in zone
-    my @clist = $entity_list->GetClientList();
-    return if (scalar(@clist) < 8);
-
     # Find visible non-GM enemies
     my @cenemies;
     foreach $pc (@clist) {


### PR DESCRIPTION
This script attempts to replicate the zone-wide aggro behavior for a_protector_of_growth, but only enables it once the zone contains enough PCs to suggest a raid.  This preserves the ability of single groups to farm gear west of the river.