### PR TITLE
Fixes Coldain Ring 9 &10 hand-ins to Dain Frostreaver.

### DIFF
--- a/thurgadinb/#Dain_Frostreaver_IV.pl
+++ b/thurgadinb/#Dain_Frostreaver_IV.pl
@@ -48,9 +48,10 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-#Handin for the 9th ring. Needs correct dialogue
-  if(plugin::check_handin(\%itemcount, 1500 => 1, 30164 => 1) && ($faction <= 5 || $faction >= 8)) {
-    quest::say("$name, you have done a great service to my people. I had not imagined the treachery had run so deeply within our ranks. Here. Take this ring as your reward. From this day forth, you shall be known as the Hero of the Coldain. Take my Dirk as well, and if you wish to further aid us in our cause, then return it to me.");
+  #Handin for the 9th ring. 
+  if($faction == 1 && plugin::check_handin(\%itemcount, 1500 => 1, 30164 => 1)) {
+    quest::say("The people of Thurgadin are in your debt, $name. Please accept the Coldain Hero's Ring as a token of our gratitude. The curse has been removed from the blade as well. I hope you find it useful against our common foes. When you are interested in assisting me further please show me the blade. Until that day, may Brell bless and protect you.");
+    #quest::say("$name, you have done a great service to my people. I had not imagined the treachery had run so deeply within our ranks. Here. Take this ring as your reward. From this day forth, you shall be known as the Hero of the Coldain. Take my Dirk as well, and if you wish to further aid us in our cause, then return it to me.");
     quest::summonitem(30369); #9th ring
     quest::summonitem(1465); #dirk of the Dain
     quest::faction(406,50); #coldain
@@ -60,7 +61,7 @@ sub EVENT_ITEM {
     quest::exp(4000000);
   }
   #Tormax's head
-  elsif(plugin::check_handin(\%itemcount, 30516 => 1) && $faction == 1) {
+  elsif($faction == 1 && plugin::check_handin(\%itemcount, 30516 => 1)) {
     quest::say("You have done what no Coldain could do, $name! This is indeed a glorious say in our people's history. In return for your invaluable service I present you with the Tri-plated Golden Hackle Hammer. Its magic is powerful and I am sure it will serve you well.");
     quest::ze(2, "Let it be know from this day forth that $name and their companions are Heros of the Coldain Kingdom. King Tormax has been slain, it is a time for celebration. Let no tankard go unfilled!");
     quest::summonitem(30502); # Item: Tri-Plated Golden Hackle Hammer
@@ -69,7 +70,7 @@ sub EVENT_ITEM {
     quest::faction(429,-100); # Faction: King Tormax
   }
 #Dirk handin for the 10th ring
-  elsif(plugin::check_handin(\%itemcount, 1465 => 1) && $faction == 1) {
+  elsif($faction == 1 && plugin::check_handin(\%itemcount, 1465 => 1)) {
     quest::say("My good $name, you have served me well. You have flushed out all who sought to oppose me and my people. I am afraid I need to call upon you and your friends one final time. The dissention and treason ran deeper than I had anticipated. Our population has been cleansed, but we lost a full third of our army to the poisonous words of those rebels. In retaliation for your deeds, the Kromrif have made plans to attack us in this, our weakest hour. Can I count on your help outlander?");
     quest::summonitem(1465); # Item: Dirk of the Dain
   }


### PR DESCRIPTION
Root cause: the order of operations causes quest items to be removed before the faction is checked.

These changes have been tested and are live on the Flavortown EQEmu server.