### PR TITLE
Fix the hand-in for the Othmir Prexus Token.

### DIFF
--- a/cobaltscar/Bloogy_Shellcracker.pl
+++ b/cobaltscar/Bloogy_Shellcracker.pl
@@ -8,7 +8,7 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-  if ((plugin::check_handin(\%itemcount, 22812 => 1) || plugin::check_handin(\%itemcount, 22813 => 1)) && plugin::check_handin(\%itemcount, 19113 => 1, 16498 => 2)) {
+  if ((plugin::check_handin(\%itemcount, 22812 => 1) || plugin::check_handin(\%itemcount, 22813 => 1)) && plugin::check_handin(\%itemcount, 19113 => 2, 16498 => 1)) {
     quest::say("It has been many moons since my people have feasted on this rarest of meat. Take this totem crafted in the form of our oceanlord Prexus and inscribed with the runes of our people. May the oceans watch over you, $name.");
     quest::summonitem(28514); #Othmir Prexus Totem
     quest::exp(15000);


### PR DESCRIPTION
The script just had the seaweed and fish eggs item IDs backwards.

Reference: http://everquest.allakhazam.com/db/quest.html?quest=960