### PR TITLE
Foresight fixes

### DIFF
--- a/chambersc/encounters/mpg_foresight.lua
+++ b/chambersc/encounters/mpg_foresight.lua
@@ -143,12 +143,12 @@ function Boss_Timer(e)
     client = eq.get_entity_list():GetRandomClient(-204,270,65,150000);
     if (client.valid) then
       num = math.random(1,table.getn(equipment));
-      equipment_client = {client, num};
+      equipment_client = {client:GetID(), num};
       client:Message(14, equipment[num][1]);
       eq.set_timer("equipment_action", 3 * 1000);
     end
   elseif (e.timer == "equipment_action") then
-    client = equipment_client[1];
+    client = eq.get_entity_list():GetClientByID(equipment_client[1]);
     if (client.valid) then 
       num = equipment_client[2];
       equipment[num][2](e.self,client);
@@ -198,12 +198,11 @@ function Kyv_Timer(e)
   local i;
   if (e.timer == 'kyv') then
     eq.stop_timer(e.timer);
-
     i = e.self:GetNPCTypeID();
     client = eq.get_entity_list():GetRandomClient(-204, 270, 65, 150000);
     if (client.valid) then
       num = math.random(1,table.getn(kyvs));
-      kyv_targets[i] = { client, num, {client:GetX(), client:GetY() }};
+      kyv_targets[i] = { client:GetID(), num, {client:GetX(), client:GetY() }};
       client:Message(14, kyvs[num][1]);
       
       eq.debug("name: " .. e.self:GetCleanName() .. i .. " timer: " .. e.timer .. " client picked: " .. client:GetName() );
@@ -212,7 +211,7 @@ function Kyv_Timer(e)
   elseif (e.timer == 'kyv_action') then
     eq.stop_timer(e.timer);
     i = e.self:GetNPCTypeID();
-    client = kyv_targets[i][1];
+	client = eq.get_entity_list():GetClientByID(kyv_targets[i][1]);
     if (client.valid) then 
       loc = kyv_targets[i][3];
       if ( kyvs[kyv_targets[i][2]][2](e, client, loc) == false ) then


### PR DESCRIPTION
I changed the client look-up to id rather than pointer.

These can cause crashes if the client object is consumed between assignment and processing due to an invalid pointer.


I checked the rest of the repo for places where 'GetRandomClient()' is called..but, I may go through the rest of it at some point and see if any other entity 'grabs' are stored improperly.