### PR TITLE
Plane of Sky quest bug fixes

### DIFF
--- a/airplane/Abec_Ianor.lua
+++ b/airplane/Abec_Ianor.lua
@@ -26,7 +26,7 @@ function event_trade(e)
 		e.other:AddEXP(100000);
 		e.self:Say("Excellent! Take this.");
 		eq.depop();
-	elseif(item_lib.check_turn_in(e.trade, {item1 = 20753, item2 = 20965, item3 = 20751, item4 = 20758})) then	--wizard test of preparation using efreeti war staff, lush nectar, copper air band, large sky sapphire
+	elseif(item_lib.check_turn_in(e.trade, {item1 = 20753, item2 = 20965, item3 = 20751, item4 = 20752})) then	--wizard test of preparation using efreeti war staff, lush nectar, copper air band, large sky sapphire (eye of the storm, 0.1 wt)
 		e.other:SummonItem(11685); --nargon's staff
 		e.other:AddEXP(100000);
 		e.self:Say("Excellent! Take this.");

--- a/airplane/Alan_Harten.lua
+++ b/airplane/Alan_Harten.lua
@@ -26,7 +26,7 @@ function event_trade(e)
 		e.other:AddEXP(100000);
 		e.self:Say("Wonderful! Take this as your reward!");
 		eq.depop();
-	elseif(item_lib.check_turn_in(e.trade, {item1 = 20946, item2 = 20829, item3 = 20811})) then	--cleric test of protection using adumbrate globe, glowing diamond, shiny pauldrons
+	elseif(item_lib.check_turn_in(e.trade, {item1 = 20946, item2 = 20810, item3 = 20811})) then	--cleric test of protection using adumbrate globe, faintly glowing diamond, shiny pauldrons
 		e.other:SummonItem(27717); --pauldrons of piety
 		e.other:AddEXP(100000);
 		e.self:Say("Wonderful! Take this as your reward!");


### PR DESCRIPTION
A few minor bug fixes for Plane of Sky quests.
- **Pauldrons of Piety** - should require a faintly glowing diamond (rather than glowing diamond, which is for the bard quest, Test of Brass). 
Reference: https://wiki.project1999.com/Cleric_Plane_of_Sky_Tests
- **Nargon's Staff** - should require Large Sky Sapphire (lore: eye of the storm, 0.1 wt). Comment was correct, but the item ID in the quest was incorrect (Ivory Pendant). 
Reference: https://wiki.project1999.com/Wizard_Plane_of_Sky_Tests