### PR TITLE
Update 38139.pl

### DIFF
--- a/tox/38139.pl
+++ b/tox/38139.pl
@@ -30,8 +30,8 @@ sub EVENT_ITEM {
 	 
 sub EVENT_WAYPOINT_ARRIVE {
 	if ($wp == 5) {
-		quest::say("Speed up the digging my pets!!");
 		if ($eventstart==0) {
+			quest::say("Speed up the digging my pets!!");
 			$skelent = $entity_list->GetMobByNpcTypeID(38016);
 			$skelnpc = $skelent->CastToNPC();
 			$skelnpc->SignalNPC(9);				


### PR DESCRIPTION
move the quest::say to only say "Speed up" if the skeletons are there, not everytime he hits this waypoint, because skeleton's wont always be there.