### PR TITLE
SendToGuildHall Update; Guild Hall Boot Idle Check

### DIFF
--- a/guildlobby/player.pl
+++ b/guildlobby/player.pl
@@ -3,16 +3,7 @@ my $Pet_ENT;
 sub EVENT_CLICKDOOR {
 	if($doorid == 2 || $doorid == 4 || $doorid == 40 || $doorid == 42) {
 		if($uguild_id > 0) {
-			if (defined($qglobals{"ginstance$uguild_id"})) {
-				$guildinstance = $qglobals{"ginstance$uguild_id"};
-				quest::AssignToInstance($guildinstance);
-				quest::MovePCInstance(345, $guildinstance, -1.00, -1.00, 3.34); # Zone: skyfire
-			} else {
-				$guildinstance = quest::CreateInstance("guildhall", 1, 86400);
-				quest::AssignToInstance($guildinstance); 
-				quest::setglobal("ginstance$uguild_id",$guildinstance,7,"H25");
-				quest::MovePCInstance(345, $guildinstance, -1.00, -1.00, 3.34); # Zone: skyfire
-			}
+			$client->SendToGuildHall();
 		}
   	} elsif((($doorid >= 5) && ($doorid <= 38)) ||  (($doorid >= 43) && ($doorid <= 76))) {
 		$client->OpenLFGuildWindow();
@@ -28,7 +19,7 @@ sub EVENT_ENTERZONE {
 
 	#if I am idle for more than xx seconds, auto-afk and go invisible/don't draw model
 	quest::settimer("afk_check", 1200); #20 minutes
-	
+
 	if(($client->GetClientVersionBit() & 4294967264)!= 0) {
 		if($client->GetInstanceID() != 5) {
 			quest::settimer(1,10);
@@ -57,9 +48,9 @@ sub EVENT_SIGNAL {
 		#}
 		#$client->Message(4, "You are no longer idle.");
 		#quest::settimer("afk_check", 1200);
-	#}	
+	#}
 }
-	
+
 sub EVENT_TIMER {
 	if($timer == 1) {
 		quest::MovePCInstance(344,5,$x,$y,$z,450); # Zone: sirens

--- a/poknowledge/player.pl
+++ b/poknowledge/player.pl
@@ -1,55 +1,48 @@
-sub EVENT_ENTERZONE
-{
+sub EVENT_ENTERZONE {
 	if (quest::istaskcompleted(138) == 0 && quest::istaskactive(138) == 0) #Check if completed Task: New Beginnings
 	{
-    	quest::assigntask(138); #Force assign Task: New Beginnings
-  	}
+		quest::assigntask(138); #Force assign Task: New Beginnings
+	}
 }
 
-sub EVENT_CLICKDOOR
-{
+sub EVENT_CLICKDOOR {
 	my $popuptext = "If you do not respond within 5 seconds, you will automatically be sent to the overhauled version.";
 
-	if($doorid == 138) #guild lobby
-  	{
-    		if($client->CalculateDistance(1408, -377, -113) <= 30)
-    		{
-      			if(($client->GetClientVersionBit() & 4294967264)!= 0)
-      			{
-        			quest::MovePCInstance(344,5,18,-46,6,450); # Zone: sirens
-      			}
-      			else
-      			{
-        			quest::movepc(344,18,-46,6,492); # Zone: sirens
-      			}
-    		}
-	}
-  	if($doorid == 139) #bazaar
-  	{
-    		if($client->CalculateDistance(1452, 347, -113) <= 30)
-    		{
-      			quest::movepc(151,-425,0,-25,65); # Zone: gukd
-    		}
-  	}
-  	if($doorid == 19)
+	if ($doorid == 138) #guild lobby
 	{
+		if ($client->CalculateDistance(1408, -377, -113) <= 30) {
+			if (($client->GetClientVersionBit() & 4294967264) != 0) {
+				quest::MovePCInstance(344, 5, 18, -46, 6, 450); # Zone: sirens
+			}
+			else {
+				quest::movepc(344, 18, -46, 6, 492); # Zone: sirens
+			}
+		}
+	}
+	if ($doorid == 139) #bazaar
+	{
+		if ($client->CalculateDistance(1452, 347, -113) <= 30) {
+			quest::movepc(151, -425, 0, -25, 65); # Zone: gukd
+		}
+	}
+	if ($doorid == 19) {
 		#$zonename = "Innothule Swamp";
 		#if(($client->GetClientVersionBit() & 3)!= 0) #062/Titanium
-	  	#{
-	  	#	quest::movepc(46,-34,-721,-27,221.21);
-	  	#}
-	  	#elsif(($client->GetClientVersionBit() & 4294967264)!= 0) #RoF+
-	  	#{
-	  	#	quest::movepc(413,-361,-462,5);
-	  	#}
-	  	#else  #SoF/SoD/UF
-	  	#{
-	  		#quest::popup("$zonename","Send you to the Classic $zonename? $popuptext",2,1);
-			#quest::settimer(2,5);
-			quest::movepc(46,-34,-721,-27,221.21); # Zone: citymist
-	  	#}
-  	}
-  	if($doorid == 22)    #erud
+		#{
+		#	quest::movepc(46,-34,-721,-27,221.21);
+		#}
+		#elsif(($client->GetClientVersionBit() & 4294967264)!= 0) #RoF+
+		#{
+		#	quest::movepc(413,-361,-462,5);
+		#}
+		#else  #SoF/SoD/UF
+		#{
+		#quest::popup("$zonename","Send you to the Classic $zonename? $popuptext",2,1);
+		#quest::settimer(2,5);
+		quest::movepc(46, -34, -721, -27, 221.21); # Zone: citymist
+		#}
+	}
+	if ($doorid == 22) #erud
 	{
 		#$zonename = "Toxxulia Forest";
 		#if(($client->GetClientVersionBit() & 3)!= 0) #062/Titanium
@@ -65,9 +58,9 @@ sub EVENT_CLICKDOOR
 		#       quest::popup("$zonename","Send you to the Classic $zonename? $popuptext",3,1);
 		#       quest::settimer(3,5);
 		#}
-		quest::movepc(38,296,-2330,-45.4,127); # Zone: chambersb
-  	}
-  	if($doorid == 32)    #paineel
+		quest::movepc(38, 296, -2330, -45.4, 127); # Zone: chambersb
+	}
+	if ($doorid == 32) #paineel
 	{
 		#$zonename = "Toxxulia Forest";
 		#if(($client->GetClientVersionBit() & 3)!= 0) #062/Titanium
@@ -83,10 +76,9 @@ sub EVENT_CLICKDOOR
 		#       quest::popup("$zonename","Send you to the Classic $zonename? $popuptext",4,1);
 		#       quest::settimer(4,5);
 		#}
-		quest::movepc(38,-569,2325,-43.4,39); # Zone: chambersb
-  	}
-  	if($doorid == 24)
-	{
+		quest::movepc(38, -569, 2325, -43.4, 39); # Zone: chambersb
+	}
+	if ($doorid == 24) {
 		#$zonename = "Steamfont Mountains";
 		#if(($client->GetClientVersionBit() & 3)!= 0) #062/Titanium
 		#{
@@ -100,11 +92,10 @@ sub EVENT_CLICKDOOR
 		#{
 		#       quest::popup("$zonename","Send you to the Classic $zonename? $popuptext",5,1);
 		#       quest::settimer(5,5);
-		       quest::movepc(56,933.79,-1358,-109); # Zone: crushbone
+		quest::movepc(56, 933.79, -1358, -109); # Zone: crushbone
 		#}
-  	}
-  	if($doorid == 25)
-	{
+	}
+	if ($doorid == 25) {
 		#$zonename = "Freeport West";
 		#if(($client->GetClientVersionBit() & 3)!= 0) #062/Titanium
 		#{
@@ -118,56 +109,66 @@ sub EVENT_CLICKDOOR
 		#{
 		#      quest::popup("$zonename","Send you to the Classic $zonename? $popuptext",6,1);
 		#      quest::settimer(6,5);
-		      quest::movepc(9,77.31,-660.57,-30.24); # Zone: arena
+		quest::movepc(9, 77.31, -660.57, -30.24); # Zone: arena
 		#}
-  	}
-}
-
-
-sub EVENT_POPUPRESPONSE
-{
-	if($popupid == 2)
-	{
-		quest::movepc(46,-34,-721,-27,221.21); # Zone: citymist
-	}
-	if($popupid == 3)
-	{
-		quest::movepc(38,296,-2330,-45.4,127); # Zone: chambersb
-	}
-	if($popupid == 4)
-	{
-                quest::movepc(38,-569,2325,-43.4,39); # Zone: chambersb
-	}
-	if($popupid == 5)
-	{
-                quest::movepc(56,933.79,-1358,-109); # Zone: crushbone
-	}
-	if($popupid == 6)
-	{
-                quest::movepc(9,77.31,-660.57,-30.24); # Zone: arena
 	}
 }
 
-sub EVENT_TIMER
-{
-	if($timer == 2)
-	{
-		quest::movepc(413,-361,-462,5); # Zone: tutorial
+
+sub EVENT_POPUPRESPONSE {
+	if ($popupid == 2) {
+		quest::movepc(46, -34, -721, -27, 221.21); # Zone: citymist
 	}
-	if($timer == 3)
-	{
-		quest::movepc(414,248,-1684,33,88); # Zone: tutoriala
+	if ($popupid == 3) {
+		quest::movepc(38, 296, -2330, -45.4, 127); # Zone: chambersb
 	}
-	if($timer == 4)
-	{
-		quest::movepc(414,-1801,1907,119,195.5); # Zone: tutoriala
+	if ($popupid == 4) {
+		quest::movepc(38, -569, 2325, -43.4, 39); # Zone: chambersb
 	}
-	if($timer == 5)
-	{
-                quest::movepc(448,940,-1122,5,98); # Zone: convorteum
+	if ($popupid == 5) {
+		quest::movepc(56, 933.79, -1358, -109); # Zone: crushbone
 	}
-	if($timer == 6)
-	{
-                quest::movepc(383,-173,-188,-69,192); # Zone: takh
+	if ($popupid == 6) {
+		quest::movepc(9, 77.31, -660.57, -30.24); # Zone: arena
 	}
+}
+
+sub EVENT_TIMER {
+	if ($timer == 2) {
+		quest::movepc(413, -361, -462, 5); # Zone: tutorial
+	}
+	if ($timer == 3) {
+		quest::movepc(414, 248, -1684, 33, 88); # Zone: tutoriala
+	}
+	if ($timer == 4) {
+		quest::movepc(414, -1801, 1907, 119, 195.5); # Zone: tutoriala
+	}
+	if ($timer == 5) {
+		quest::movepc(448, 940, -1122, 5, 98); # Zone: convorteum
+	}
+	if ($timer == 6) {
+		quest::movepc(383, -173, -188, -69, 192); # Zone: takh
+	}
+
+	if ($timer eq "check_idle") {
+		my $last_x  = $client->GetEntityVariable("last_x");
+		my $last_y  = $client->GetEntityVariable("last_y");
+		my $is_idle = ($last_x eq $client->GetX() && $last_y eq $client->GetY());
+
+		if ($is_idle && $uguild_id > 0) {
+			$client->SendToGuildHall();
+		}
+
+		set_current_position();
+	}
+}
+
+sub EVENT_SAY {
+	quest::settimer("check_idle", 1200);
+	set_current_position();
+}
+
+sub set_current_position() {
+	$client->SetEntityVariable("last_x", $client->GetX());
+	$client->SetEntityVariable("last_y", $client->GetY());
 }

--- a/poknowledge/player.pl
+++ b/poknowledge/player.pl
@@ -3,6 +3,9 @@ sub EVENT_ENTERZONE {
 	{
 		quest::assigntask(138); #Force assign Task: New Beginnings
 	}
+
+	set_current_position();
+	quest::settimer("check_idle", 1200);
 }
 
 sub EVENT_CLICKDOOR {
@@ -161,11 +164,6 @@ sub EVENT_TIMER {
 
 		set_current_position();
 	}
-}
-
-sub EVENT_SAY {
-	quest::settimer("check_idle", 1200);
-	set_current_position();
 }
 
 sub set_current_position() {


### PR DESCRIPTION
Update Guild Lobby doors to use SendToGuildHall call

Boot players in PoK who are idle for 20 minutes to Guild Hall, we can refine this logic later if we want, just getting something in place 