### PR TITLE
Fix pojustice trials to use IDs and look up objects

### DIFF
--- a/pojustice/201435.lua
+++ b/pojustice/201435.lua
@@ -4,18 +4,17 @@
 -- items: 31599
 
 local lashing_flag      = 0;
-local trial_group       = nil;
-local trial_count       = nil;
-local client_e          = nil;
+local trial_group_id    = 0;
+local client_id         = 0; -- character ID, not entity ID
 local trial_x           = 1373;
 local trial_y           = -1125;
 local trial_z           = 1;
 local trial_h           = 60;
-local trial_mobs			= { 201463, 201464, 201465, 201466, 201467, 201468, 201469 };
+local trial_mobs        = { 201463, 201464, 201465, 201466, 201467, 201468, 201469 };
 
-local cooldown_timer		= 1800000;
-local eject_timer			= 900000;
-local fail_timer			= 360000;
+local cooldown_timer    = 1800000;
+local eject_timer       = 900000;
+local fail_timer        = 360000;
 
 function event_say(e)
    local qglobals = eq.get_qglobals(e.self,e.other);
@@ -32,11 +31,12 @@ function event_say(e)
             e.self:Say("Then begin.");
 
             -- Move the Player and their Group tot he trial room.
-            trial_group = e.other:GetGroup();
-            if ( trial_group.valid ) then
+            local trial_group = e.other:GetGroup();
+            if (trial_group ~= nil and trial_group.valid) then
                MoveGroup( trial_group, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 75, trial_x, trial_y, trial_z, trial_h); 
+               trial_group_id = trial_group:GetID();
             else
-               client_e = e;
+               client_id = e.other:CharacterID();
                e.other:MovePC(201, trial_x, trial_y, trial_z, trial_h); -- Zone: pojustice
             end
 
@@ -79,30 +79,30 @@ function event_say(e)
 end
 
 function event_timer(e)
-
    if (e.timer == "ejecttimer") then
-
       eq.stop_timer(e.timer);
       despawn_trial_mobs()
 
+      local trial_group = eq.get_entity_list():GetGroupByID(trial_group_id);
       if (trial_group ~= nil and trial_group.valid) then
          MoveGroup( trial_group, trial_x, trial_y, trial_z, 250, 456, 825, 9, 180, "A mysterious force translocates you."); 
       else
-         client_e.other:MovePC( 201, 456, 825, 9, 360 ); -- Zone: pojustice
-			client_e.other:Message( 3, "A mysterious force translocates you.");
+          local client_e = eq.get_entity_list():GetClientByCharID(client_id);
+          if (client_e ~= nil and client_e.valid) then
+              client_e.other:MovePC( 201, 456, 825, 9, 360 ); -- Zone: pojustice
+              client_e.other:Message( 3, "A mysterious force translocates you.");
+          end
       end
       HandleCorpses(trial_x, trial_y, trial_z, 200);
 
       eq.stop_timer("proximitycheck");
 
    elseif (e.timer == "cooldown") then
-      
       eq.stop_timer(e.timer);
 
       lashing_flag   = 0;
-      client_e         = nil;
-      trial_group      = nil;
-      trial_count      = nil;
+      client_id      = 0;
+      trial_group_id = 0;
 
       despawn_trial_mobs();
 
@@ -129,9 +129,8 @@ function event_timer(e)
 end
 
 function event_signal(e)
-   -- 
    if (e.signal == 0) then
-      
+
    elseif (e.signal == 1) then
       -- Trial was successful
       -- 30min till next Trial can start

--- a/pojustice/201436.lua
+++ b/pojustice/201436.lua
@@ -5,10 +5,9 @@
 -- @variable hanging_flag
 --  0 - Trial is available
 --  1 - Trial is unavailable
-local hanging_flag  	  = 0;
-local trial_group         = nil;
-local trial_count         = nil;
-local client_e            = nil;
+local hanging_flag        = 0;
+local trial_group_id      = 0;
+local client_id           = 0; -- character ID, not entity ID
 local mob_list            = { 201456, 201457, 201458, 201459, 201460, 201461, 201471, 201472, 201473, 201474 }
 
 -- 30min Cooldown on a Successful Completion
@@ -31,12 +30,12 @@ function event_say(e)
             e.self:Say("Then begin.");
 
             -- Move the Player and their Group tot he trial room.
-            trial_group = e.other:GetGroup();
-
-            if ( trial_group.valid ) then
+            local trial_group = e.other:GetGroup();
+            if (trial_group ~= nil and trial_group.valid) then
                MoveGroup( trial_group, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 75, 490, -1094, 73, 180); 
+               trial_group_id = trial_group:GetID();
             else
-               client_e = e;
+               client_id = e.other:CharacterID();
                e.other:MovePC(201, 490, -1094, 73, 360); -- Zone: pojustice
             end
 
@@ -77,15 +76,17 @@ end
 
 
 function event_timer(e)
-
    if (e.timer == "ejecttimer") then
-
       eq.stop_timer(e.timer);
-      if (trial_group.valid) then
+      local trial_group = eq.get_entity_list():GetGroupByID(trial_group_id);
+      if (trial_group ~= nil and trial_group.valid) then
 			MoveGroup( trial_group, 490, -1094, 73, 140, 456, 825, 9, 180); 
       else
-         client_e.other:MovePC( 201, 456, 825, 9, 360 ); -- Zone: pojustice
-			client_e.other:Message(3, "A mysterious force translocates you.");
+          local client_e = eq.get_entity_list():GetClientByCharID(client_id);
+          if (client_e ~= nil and client_e.valid) then
+              client_e.other:MovePC( 201, 456, 825, 9, 360 ); -- Zone: pojustice
+              client_e.other:Message( 3, "A mysterious force translocates you.");
+          end
       end
 
       HandleCorpses(450, -1120, 72, 120);
@@ -93,13 +94,11 @@ function event_timer(e)
       eq.stop_timer("proximitycheck");
 
    elseif (e.timer == "cooldown") then
-      
       eq.stop_timer(e.timer);
 
       hanging_flag   = 0;
-      client_e         = nil;
-      trial_group      = nil;
-      trial_count      = nil;
+      client_id      = 0;
+      trial_group_id = 0;
 
       eq.stop_timer("proximitycheck");
       e.self:Shout("The Trial of Hanging is now Available.");
@@ -123,9 +122,8 @@ function event_timer(e)
 end
 
 function event_signal(e)
-   -- 
    if (e.signal == 0) then
-      
+
    elseif (e.signal == 1) then
       -- Trial was successful
       -- 30min till next Trial can start

--- a/pojustice/201437.lua
+++ b/pojustice/201437.lua
@@ -4,18 +4,17 @@
 -- items: 31599
 
 local stoning_flag      = 0;
-local trial_group       = nil;
-local trial_count       = nil;
-local client_e          = nil;
+local trial_group_id    = 0;
+local client_id         = 0; -- character ID, not entity ID
 local trial_x           = -133;
 local trial_y           = -1107;
 local trial_z           = 73;
 local trial_h           = 126;
-local trial_mobs			= { 201451, 201493, 21494, 201495, 201496, 201497, 201498, 201499 };
+local trial_mobs        = { 201451, 201493, 21494, 201495, 201496, 201497, 201498, 201499 };
 
-local cooldown_timer		= 1800000;
-local eject_timer			= 900000;
-local fail_timer			= 360000;
+local cooldown_timer    = 1800000;
+local eject_timer       = 900000;
+local fail_timer        = 360000;
 
 function event_say(e)
    local qglobals = eq.get_qglobals(e.self,e.other);
@@ -32,12 +31,12 @@ function event_say(e)
             e.self:Say("Then begin.");
 
             -- Move the Player and their Group tot he trial room.
-            trial_group = e.other:GetGroup();
-            if ( trial_group.valid ) then
+            local trial_group = e.other:GetGroup();
+            if (trial_group ~= nil and trial_group.valid) then
                MoveGroup( trial_group, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 75, trial_x, trial_y, trial_z, trial_h); 
-					client_e = e;
+               trial_group_id = trial_group:GetID();
             else
-               client_e = e;
+               client_id = e.other:CharacterID();
                e.other:MovePC(201, trial_x, trial_y, trial_z, trial_h); -- Zone: pojustice
             end
 
@@ -81,32 +80,30 @@ function event_say(e)
 end
 
 function event_timer(e)
-
    if (e.timer == "ejecttimer") then
-
       eq.stop_timer(e.timer);
       despawn_trial_mobs()
 
+      local trial_group = eq.get_entity_list():GetGroupByID(trial_group_id);
       if (trial_group ~= nil and trial_group.valid) then
          MoveGroup( trial_group, trial_x, trial_y, trial_z, 250, 456, 825, 9, 180, "A mysterious force translocates you."); 
       else
-			if (client_e ~= nil) then
-				client_e.other:MovePC( 201, 456, 825, 9, 360 ); -- Zone: pojustice
-				client_e.other:Message(3, "A mysterious force translocates you.");
-			end
+          local client_e = eq.get_entity_list():GetClientByCharID(client_id);
+          if (client_e ~= nil and client_e.valid) then
+              client_e.other:MovePC( 201, 456, 825, 9, 360 ); -- Zone: pojustice
+              client_e.other:Message(3, "A mysterious force translocates you.");
+          end
       end
       HandleCorpses(trial_x, trial_y, trial_z, 200);
 
       eq.stop_timer("proximitycheck");
 
    elseif (e.timer == "cooldown") then
-      
       eq.stop_timer(e.timer);
 
       stoning_flag   = 0;
-      client_e         = nil;
-      trial_group      = nil;
-      trial_count      = nil;
+      client_id      = 0;
+      trial_group_id = 0;
 
       despawn_trial_mobs();
 
@@ -133,9 +130,8 @@ function event_timer(e)
 end
 
 function event_signal(e)
-   -- 
    if (e.signal == 0) then
-      
+
    elseif (e.signal == 1) then
       -- Trial was successful
       -- 30min till next Trial can start

--- a/pojustice/201438.lua
+++ b/pojustice/201438.lua
@@ -3,14 +3,13 @@
 --
 -- items: 31599
 
-local torture_flag	= 0;
-local trial_group		= nil;
-local trial_count		= nil;
-local client_e			= nil;
-local	mob_list			= { };
+local torture_flag   = 0;
+local trial_group_id = 0;
+local client_id      = 0; -- character ID, not entity ID
+local mob_list       = { };
 
 local cooldown_timer = 1800000;
-local eject_timer		= 900000;
+local eject_timer    = 900000;
 
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.self,e.other);
@@ -27,12 +26,12 @@ function event_say(e)
 				e.self:Say("Then begin.");
 
 				-- Move the Player and their Group tot he trial room.
-				trial_group = e.other:GetGroup();
-				if ( trial_group.valid ) then
+				local trial_group = e.other:GetGroup();
+				if (trial_group ~= nil and trial_group.valid) then
 					MoveGroup( trial_group, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 75, 729, -1119, 88, 64); 
-					client_e = e;
+					trial_group_id = trial_group:GetID();
 				else
-					client_e = e;
+					client_id = e.other:CharacterID();
 					e.other:MovePC(201, 729, -1119, 88, 128); -- Zone: pojustice
 				end
 
@@ -75,30 +74,30 @@ function event_say(e)
 end
 
 function event_timer(e)
-
 	if (e.timer == "ejecttimer") then
-
 		eq.stop_timer(e.timer);
 		despawn_trial_mobs()
 
+        local trial_group = eq.get_entity_list():GetGroupByID(trial_group_id);
 		if (trial_group ~= nil and trial_group.valid) then
 			MoveGroup( trial_group, 772, -1148, 76, 175, 456, 825, 9, 180, "A mysterious force translocates you."); 
 		else
-			client_e.other:MovePC( 201, 456, 825, 9, 360 ); -- Zone: pojustice
-			client_e.other:Message(3, "A mysterious force translocates you.");
+            local client_e = eq.get_entity_list():GetClientByCharID(client_id);
+            if (client_e ~= nil and client_e.valid) then
+                client_e.other:MovePC( 201, 456, 825, 9, 360 ); -- Zone: pojustice
+                client_e.other:Message(3, "A mysterious force translocates you.");
+            end
 		end
 		HandleCorpses(772, -1148, 76, 175);
 
 		eq.stop_timer("proximitycheck");
 
 	elseif (e.timer == "cooldown") then
-		
 		eq.stop_timer(e.timer);
 
-		torture_flag	= 0;
-		client_e			= nil;
-		trial_group		= nil;
-		trial_count		= nil;
+        torture_flag   = 0;
+        client_id      = 0;
+        trial_group_id = 0;
 
 		despawn_trial_mobs();
 


### PR DESCRIPTION
This should avoid crashes from stale "pointers"