### PR TITLE
improve Rineval prompts to be more in line with live.

### DIFF
--- a/qeynos2/Rineval_Talyas.lua
+++ b/qeynos2/Rineval_Talyas.lua
@@ -1,11 +1,12 @@
 -- items: 19071, 19070, 1000, 18302
 function event_say(e)
 	if(e.message:findi("hail")) then
-		e.self:Say(string.format("hello, %s",e.other:GetName()));
+		e.self:Say("hello, " .. e.other:GetName());
 	elseif(e.message:findi("scribe")) then
-		e.self:Emote(string.format("looks at %s strangely. 'Who told you this?'",e.other:GetName()));
-	elseif(e.message:findi("Karn")) then
-		e.self:Say("'I see. If a scribe is what you seek, then bring me the torn books of fire and ice. A donation of 1000 platinum is needed as well. The donation will be offered as a blessing to the gods.");
+		e.self:Emote("looks at " .. e.other:GetName() .. " strangely. 'Who told you this?'");
+	elseif(e.message:findi("told me")) then
+		-- NOTE: this is buggy but live-like. The real prompt should be "Kanthurn" or "Kanthurn told me", but that does not work on live /june 2022
+		e.self:Say("I see. If a scribe is what you seek, then bring me the torn books of fire and ice. A donation of 1000 platinum is needed as well. The donation will be offered as a blessing to the gods.");
 	end
 end
 


### PR DESCRIPTION
This is related to #1346.

Please note that one of these prompts are bugged, and the same is true on live.

This PR implements the observations from the end of this zam comment: https://everquest.allakhazam.com/db/npc.html?id=6481#m1376551132191625559
> (You can actually say "(Anyone) told me" for this prompt and she will reply, so saying "Karn told me" as the guide states will work, or just "told me.")
