### PR TITLE
fix unnecessary zoning for clients

### DIFF
--- a/commonlands/player.lua
+++ b/commonlands/player.lua
@@ -1,7 +1,7 @@
 function event_enter_zone(e)
   local client = eq.get_entity_list():GetClientByID(e.self:GetID());
   
-  if(($client->GetClientVersionBit() & 3) != 0) { #062/Titanium
-    client:MovePC(22, -144, -1543, 2, 244); -- Zone: ecommons
+  if((client.GetClientVersionBit() & 3) != 0) { #062/Titanium
+    client:MovePCInstance(22, -144, -1543, 2, 244); -- Zone: ecommons
   }
 end

--- a/commonlands/player.lua
+++ b/commonlands/player.lua
@@ -1,7 +1,7 @@
 function event_enter_zone(e)
   local client = eq.get_entity_list():GetClientByID(e.self:GetID());
   
-  if((client.GetClientVersionBit() & 3) != 0) { #062/Titanium
+  if((client.GetClientVersionBit() & 3) != 0) { -- 062/Titanium
     client:MovePCInstance(22, -144, -1543, 2, 244); -- Zone: ecommons
   }
 end

--- a/commonlands/player.lua
+++ b/commonlands/player.lua
@@ -1,4 +1,7 @@
 function event_enter_zone(e)
   local client = eq.get_entity_list():GetClientByID(e.self:GetID());
-  client:MovePC(22, -144, -1543, 2, 244); -- Zone: ecommons
+  
+  if(($client->GetClientVersionBit() & 3) != 0) { #062/Titanium
+    client:MovePCInstance(22, -144, -1543, 2, 244); -- Zone: ecommons
+  }
 end

--- a/commonlands/player.lua
+++ b/commonlands/player.lua
@@ -1,7 +1,8 @@
 function event_enter_zone(e)
   local client = eq.get_entity_list():GetClientByID(e.self:GetID());
   
-  if((client.GetClientVersionBit() & 3) != 0) { -- 062/Titanium
-    client:MovePCInstance(22, -144, -1543, 2, 244); -- Zone: ecommons
-  }
+-- If not Rof2 client; move them to east commonland ldon camp. Commons not yet implemented
+  if (bit.band(client:GetClientVersionBit(), 4294967264) == 0) then
+    client.MovePC(22, -144, -1543, 2, 244); -- Zone: ecommons
+  end
 end

--- a/commonlands/player.lua
+++ b/commonlands/player.lua
@@ -2,6 +2,6 @@ function event_enter_zone(e)
   local client = eq.get_entity_list():GetClientByID(e.self:GetID());
   
   if(($client->GetClientVersionBit() & 3) != 0) { #062/Titanium
-    client:MovePCInstance(22, -144, -1543, 2, 244); -- Zone: ecommons
+    client:MovePC(22, -144, -1543, 2, 244); -- Zone: ecommons
   }
 end


### PR DESCRIPTION
This is only a tentative fix, but I ran into an issue with the RoF2 client where zoning into an East Commons zone triggered a player teleport to a different zone and location, which then caused a breaking issue when the player tried to zone into West Commons, as the zone file for that zone isn't available with that Client.

It might be better to remove this trigger altogether, but I don't know enough to understand the value of attempting to teleport all players to the middle of EC tunnels. If there are any other suggestions on how best to address this, I am happy to investigate further.

This issue was reported in 2018 as well, http://www.eqemulator.org/forums/showthread.php?t=41900