### PR TITLE
[DZ] Tacvi Overhaul Including DZ Support

### DIFF
--- a/tacvi/#Sesnil_Yisnon.lua
+++ b/tacvi/#Sesnil_Yisnon.lua
@@ -1,43 +1,22 @@
 function event_say(e)
-  if (e.message:findi("hail")) then
-
-    e.self:Say("The spirits of this temple whispered of your coming and you have arrived none too soon. The leader of the Muramite army has taken up residence here along with three of his officers. They have destroyed all that stood as a symbol of the Taelosians and now as we stand here, the torture continues. I am all that is left of the slaves they brought here to experiment on. As you can see from the corpses that lie here, some of us did not even make it out of this room before we collapsed from fright of what was to come. Since the Wayfarers Brotherhood's arrival on our continent, I have been waiting for someone to get this far and save us. But you are not the first and I fear you will not be the last, for you see I have helped many others make it through this sacred place and now their remains clutter the hallways of this once glorious temple. The might of this army is at its strongest here and there is no mercy for the weak who challenge them.");
-    e.self:Say("Now that you have heard my tale do you wish to [" .. eq.say_link("continue") .. "]?' ");
-  elseif (e.message:findi("continue")) then
-    e.self:Say("I am bound to help avenge the deaths of my people by the invading masses of the Muramite army. Until this is done I must help any who enter here. If you destroy the commander then you will free my spirit and the others who are stuck here. I will remove the seal on this door when you say you are [" .. eq.say_link("ready") .. "].");
-
-  elseif (e.message:findi("ready")) then
-    e.self:MoveTo(11.57, -38.06, -6.87, 155.6, true);
-    e.self:Emote("begins to recite an incantation in his native tongue. Waving his arms in the air, you see the door light up and go dim just as his arms come to rest at his side. 'There you are. The seal has been removed. Now once again you must destroy the guardian in the doorway and do not venture back until you have destroyed the being within, or you will be destroyed by the wards.'"); 
-
-    
-
-    local door = 0;
-    local entity_list = eq.get_entity_list();
-    door = entity_list:FindDoor(18);
-    if (door ~= nil) then
-        door:SetLockPick(0);
-      end
-
-  elseif (e.message:findi("lockout")) then
-
-    local instance_requests = require("instance_requests");
-    local lockout_globals = {
-      { "Tacvi_PXK", "Tacvi: Pixtt Xxeric Kex" },
-      { "Tacvi_PKK", "Tacvi: Pixtt Kretv Krakxt" },
-      { "Tacvi_PRT", "Tacvi: Pixtt Riel Tavas" },
-      { "Tacvi_ZMKP", "Tacvi: Zun`Muram Kvxe Pirik" },
-      { "Tacvi_ZMSB", "Tacvi: Zun`Muram Shaldn Boc" },
-      { "Tacvi_ZMMD", "Tacvi: Zun`Muram Mordl Delt" },
-      { "Tacvi_ZMYV", "Tacvi: Zun`Muram Yihst Vor" },
-      { "Tacvi_TMCV", "Tacvi: Tunat`Muram Cuu Vauax" }
-    }
-    instance_requests.DisplayLockouts(e.other, e.other, lockout_globals)
-
-  end
-
+	if (e.message:findi("hail")) then
+		e.self:Say("The spirits of this temple whispered of your coming and you have arrived none too soon. The leader of the Muramite army has taken up residence here along with three of his officers. They have destroyed all that stood as a symbol of the Taelosians and now as we stand here, the torture continues. I am all that is left of the slaves they brought here to experiment on. As you can see from the corpses that lie here, some of us did not even make it out of this room before we collapsed from fright of what was to come. Since the Wayfarers Brotherhood's arrival on our continent, I have been waiting for someone to get this far and save us. But you are not the first and I fear you will not be the last, for you see I have helped many others make it through this sacred place and now their remains clutter the hallways of this once glorious temple. The might of this army is at its strongest here and there is no mercy for the weak who challenge them.");
+		e.self:Say("Now that you have heard my tale do you wish to [" .. eq.say_link("continue") .. "]?' ");
+	elseif (e.message:findi("continue")) then
+		e.self:Say("I am bound to help avenge the deaths of my people by the invading masses of the Muramite army. Until this is done I must help any who enter here. If you destroy the commander then you will free my spirit and the others who are stuck here. I will remove the seal on this door when you say you are [" .. eq.say_link("ready") .. "].");
+	elseif (e.message:findi("ready")) then
+		e.self:MoveTo(11.57, -38.06, -6.87, 155.6, true);
+		e.self:Emote("Sesnil begins to recite an incantation in his native tongue. Waving his arms in the air, you see the door light up and go dim just as his arms come to rest at his side. 'There you are. The seal has been removed. Now once again you must destroy the guardian in the doorway and do not venture back until you have destroyed the being within, or you will be destroyed by the wards.'"); 
+		
+		local door = 0;
+		local entity_list = eq.get_entity_list();
+		door = entity_list:FindDoor(18);
+		if door ~= nil then
+			door:SetLockPick(0);
+		end
+	end
 end
 
 function event_waypoint_arrive(e)
-  eq.zone_emote(15,"An ancient hallway lies before you. The remains of fallen warriors litter the floor along with discarded slave corpses.");
+	eq.zone_emote(15,"An ancient hallway lies before you. The remains of fallen warriors litter the floor along with discarded slave corpses.");
 end

--- a/tacvi/#Sesnil_Yisnon.lua
+++ b/tacvi/#Sesnil_Yisnon.lua
@@ -18,5 +18,5 @@ function event_say(e)
 end
 
 function event_waypoint_arrive(e)
-	eq.zone_emote(15,"An ancient hallway lies before you. The remains of fallen warriors litter the floor along with discarded slave corpses.");
+	eq.zone_emote(MT.Yellow,"An ancient hallway lies before you. The remains of fallen warriors litter the floor along with discarded slave corpses.");
 end

--- a/tacvi/an_elite_mastruq_berserker.lua
+++ b/tacvi/an_elite_mastruq_berserker.lua
@@ -1,8 +1,8 @@
---tacvi mastruq mods
+-- acvi mastruq mods
 
 function event_spawn(e)
-e.self:ModSkillDmgTaken(0, -30); -- 1h blunt
-e.self:ModSkillDmgTaken(2, -30); -- 2h blunt
-e.self:ModSkillDmgTaken(1, 10); -- 1h slashing
-e.self:ModSkillDmgTaken(3, 10); -- 2h slashing
+	e.self:ModSkillDmgTaken(0, -30); -- 1h blunt
+	e.self:ModSkillDmgTaken(2, -30); -- 2h blunt
+	e.self:ModSkillDmgTaken(1, 10); -- 1h slashing
+	e.self:ModSkillDmgTaken(3, 10); -- 2h slashing
 end

--- a/tacvi/an_elite_mastruq_crusher.lua
+++ b/tacvi/an_elite_mastruq_crusher.lua
@@ -1,8 +1,8 @@
---tacvi mastruq mods
+-- tacvi mastruq mods
 
 function event_spawn(e)
-e.self:ModSkillDmgTaken(0, -30); -- 1h blunt
-e.self:ModSkillDmgTaken(2, -30); -- 2h blunt
-e.self:ModSkillDmgTaken(1, 10); -- 1h slashing
-e.self:ModSkillDmgTaken(3, 10); -- 2h slashing
+	e.self:ModSkillDmgTaken(0, -30); -- 1h blunt
+	e.self:ModSkillDmgTaken(2, -30); -- 2h blunt
+	e.self:ModSkillDmgTaken(1, 10); -- 1h slashing
+	e.self:ModSkillDmgTaken(3, 10); -- 2h slashing
 end

--- a/tacvi/an_elite_mastruq_destroyer.lua
+++ b/tacvi/an_elite_mastruq_destroyer.lua
@@ -1,8 +1,8 @@
---tacvi mastruq mods
+-- tacvi mastruq mods
 
 function event_spawn(e)
-e.self:ModSkillDmgTaken(0, -30); -- 1h blunt
-e.self:ModSkillDmgTaken(2, -30); -- 2h blunt
-e.self:ModSkillDmgTaken(1, 10); -- 1h slashing
-e.self:ModSkillDmgTaken(3, 10); -- 2h slashing
+	e.self:ModSkillDmgTaken(0, -30); -- 1h blunt
+	e.self:ModSkillDmgTaken(2, -30); -- 2h blunt
+	e.self:ModSkillDmgTaken(1, 10); -- 1h slashing
+	e.self:ModSkillDmgTaken(3, 10); -- 2h slashing
 end

--- a/tacvi/encounters/pkk.lua
+++ b/tacvi/encounters/pkk.lua
@@ -1,244 +1,164 @@
---[[
--- PKK Event
--- Pixtt Kretv Krakxt
--- http://everquest.allakhazam.com/db/quest.html?quest=4262
---
--- Pixtt Kretv Krakxt says 'You shall regret trespassing into my chambers. The might of our kind shall smother the flames of life in this world, starting with you.'
---
--- Do you really think your paltry skills will be enough to best a being as powerful as I?
---
---
--- Pixtt Kretv Krakxt: Fight Details & Mechanics
---
--- Pixtt Kretv Krakxt hits for a max ~4,800. During this encounter, she will "feign death" four different times: Once at 90%, 70%, 50%, and 30%. Each time she does this, numerous mobs called "an ikaav hatchling" spawn and must be killed to progress the event. These adds each hit for a max ~1,500; single-target rampage; and are mezzable. Also appearing at this time are non-attackable mobs called "Reflection of Pixtt Kretv Krakxt" that wander the perimeter of the room casting AEs.
---
---
--- Pixtt Kretv Krakxt at 90%
---
--- Ha ha ha, you fools thought you could overpower me. You are nothing but food for my offspring. Come my children, strike them down and suck the marrow from their bones.' Kretv's body falls to the ground -- a lifeless husk freeing the hatchlings within.
---
--- 4x "an ikaav hatchling" spawn and 1x "Reflection of Pixtt Kretv Krakxt" (unattackable) roams the perimeter of the room casting "Wrath of the Ikaav" (7k DD + Feign Death) on random people. After the four hatchlings are dead, Pixtt Kretv Krakxt resumes attacking.
---
--- Each hatchling is stunnable and mezzable, and has about 50,000 hitpoints.
---
---
--- Pixtt Kretv Krakxt at 70%
---
--- Your efforts shall fail no matter how great. This is a reality you shall soon see as your vile existence ceases and my brood consumes your remains.
---
--- 5x "an ikaav hatchling" spawn and 2x "Reflection of Pixtt Kretv Krakxt" (unattackable) roam the perimeter of the room casting "Wrath of the Ikaav" (7k DD + Feign Death) on random people. After the five hatchlings are dead, Pixtt Kretv Krakxt resumes attacking.
---
---
--- Pixtt Kretv Krakxt at 50%
---
--- You show surprising strength and conviction, but you will not get any further. The time has come for you to be destroyed.
---
--- 6x "an ikaav hatchling" spawn and 3x "Reflection of Pixtt Kretv Krakxt" (unattackable) roam the perimeter of the room casting "Wrath of the Ikaav" (7k DD + Feign Death) on random people and "Ikaav Venom" (AE slow). After the six hatchlings are dead, Pixtt Kretv Krakxt resumes attacking.
---
---
--- Pixtt Kretv Krakxt at 30%
---
--- My resolve is waning but I shall fight you to the very last breath. The commander looks down upon weaklings in his ranks and the ikaav are not ones to indulge in it.
---
--- 7x "an ikaav hatchling" spawn and 4x "Reflection of Pixtt Kretv Krakxt" (unattackable) roam the perimeter of the room casting "Wrath of the Ikaav" (7k DD + Feign Death) on random people and "Ikaav Venom" (AE slow). After the seven hatchlings are dead, Pixtt Kretv Krakxt resumes attacking.
---
---
--- Pixtt Kretv Krakxt at 10%
---
--- At approximately 10%, you see this:
---
--- The end is inevitable, but if I must be defeated, some of you will join me in the afterlife.
---
--- At this time, Pixtt Kretv Krakxt begins AE rampaging for full damage, and won't stop until her death. Also at this point, you get 3x "an ikaav hatchling" adds.
---
---
--- Completion & Loot
---
--- Pixtt Kretv Krakxt has been slain by _____!
---
--- Kretv's body falls to the stone floor in a puddle of blackened blood. You step back as she slashes one last time, connecting with nothing but the stale air of the room. 'This is not over. My commander will destroy you for this and when he does I hope it is my power he is wielding.
---
--- With the death of the great beast, the seals on the doors fade away. Your path is now clear.
---
--- The remaining hatchlings do not despawn upon her death. They must be killed.
---
---]]
 local hatchlings_spawned = 0;
 local hatchlings_killed = 0;
-
 local PKK_hitpoints = 100; -- Also reset to 100 on wipe
 
 function PKK_Spawn(e)
-  e.self:ModSkillDmgTaken(3, -30); -- 2h slashing
-  e.self:ModSkillDmgTaken(1, -30); -- 1h slashing
-e.self:ModSkillDmgTaken(7, -25); -- archery
-  if (PKK_hitpoints == 100) then -- First spawn/wipe!
-    eq.set_next_hp_event(90);
-
-    hatchlings_spawned = 0;
-    hatchlings_killed = 0;
-
-    eq.get_entity_list():FindDoor(5):SetLockPick(0);
-  else -- Respawning because all hatchlings are dead
-    eq.depop_all(298047); -- husk
-    e.self:SetHP(e.self:GetMaxHP() * (PKK_hitpoints / 100.0));
-    if (PKK_hitpoints == 90) then
-       eq.set_next_hp_event(70);
-    elseif (PKK_hitpoints == 70) then
-       eq.set_next_hp_event(50);
-    elseif (PKK_hitpoints == 50) then
-       eq.set_next_hp_event(30);
-    elseif (PKK_hitpoints == 30) then
-       eq.set_next_hp_event(10);
-    end
-  end
+	e.self:ModSkillDmgTaken(3, -30); -- 2h slashing
+	e.self:ModSkillDmgTaken(1, -30); -- 1h slashing
+	e.self:ModSkillDmgTaken(7, -25); -- archery
+	if PKK_hitpoints == 100 then -- First spawn/wipe!
+		eq.set_next_hp_event(90);
+		hatchlings_spawned = 0;
+		hatchlings_killed = 0;
+		eq.signal(298223,2); -- Unlock Doors
+	else -- Respawning because all hatchlings are dead
+		eq.depop_all(298047); -- husk
+		e.self:SetHP(e.self:GetMaxHP() * (PKK_hitpoints / 100.0));
+		if PKK_hitpoints == 90 then
+			 eq.set_next_hp_event(70);
+		elseif PKK_hitpoints == 70 then
+			 eq.set_next_hp_event(50);
+		elseif PKK_hitpoints == 50 then
+			 eq.set_next_hp_event(30);
+		elseif PKK_hitpoints == 30 then
+			 eq.set_next_hp_event(10);
+		end
+	end
 end
 
 function PKK_Death(e)
-  eq.signal(298223, 298201); -- NPC: zone_status
-  eq.get_entity_list():FindDoor(5):SetLockPick(0);
+	eq.signal(298223, 298201); -- NPC: zone_status
+	eq.signal(298223,2,1000); -- Unlock Doors
 end
 
 function PKK_Combat(e)
-  if (e.joined == true) then
-    e.self:Say("You shall regret trespassing into my chambers. The might of our kind shall smother the flames of life in this world, starting with you.");
-
-    e.self:Say("Do you really think your paltry skills will be enough to best a being as powerful as I?");
-		if (e.self:GetHPRatio() < 92) then
-			eq.set_timer("check", 1 * 1000); -- set scorpion timer on future phases
-		end
-  elseif (e.joined == false) then
-    eq.set_timer("wipecheck", 5000);
-	eq.stop_timer("check");
-  end
+	if e.joined then
+		e.self:Say("You shall regret trespassing into my chambers. The might of our kind shall smother the flames of life in this world, starting with you.");
+		e.self:Say("Do you really think your paltry skills will be enough to best a being as powerful as I? ");
+			if (e.self:GetHPRatio() < 92) then
+				eq.set_timer("check", 1 * 1000); -- set scorpion timer on future phases
+			end
+	elseif not e.joined then
+		eq.set_timer("wipecheck", 5000);
+		eq.stop_timer("check");
+	end
 end
 
 function PKK_Husk_Spawn(e)
-  eq.set_timer("wipecheck", 1500);
+	eq.set_timer("wipecheck", 1500);
 end
 
 function PKK_Timer(e)
-  if (e.timer == "wipecheck") then
-    -- Check to see if there are any Clients in the room with PKK
-    local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 5000);
-    if (client:IsClient() == false) then
-      PKK_hitpoints = 100;
-      eq.depop_all(298203); -- Reflection 1
-      eq.depop_all(298204); -- Reflection 2
-      eq.depop_all(298046); -- Reflection 3
-      eq.depop_all(298146); -- Reflection 4
-      eq.depop_all(298048); -- Hatchling
-      eq.depop(); -- will depop either husk or PKK
-      eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378); -- NPC: Pixtt_Kretv_Krakxt
-      eq.get_entity_list():FindDoor(5):SetLockPick(0);
-    end
-  elseif (e.timer == "tenae") then
-      e.self:CastSpell(eq.ChooseRandom(889, 887, 751, 888),e.self:GetTarget():GetID());
-elseif (e.timer == "check") then
-		
+	if (e.timer == "wipecheck") then
+		-- Check to see if there are any Clients in the room with PKK
+		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 5000);
+		if (client:IsClient() == false) then
+			PKK_hitpoints = 100;
+			eq.depop_all(298203); -- Reflection 1
+			eq.depop_all(298204); -- Reflection 2
+			eq.depop_all(298046); -- Reflection 3
+			eq.depop_all(298146); -- Reflection 4
+			eq.depop_all(298048); -- Hatchling
+			eq.depop(); -- will depop either husk or PKK
+			eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378); -- NPC: Pixtt_Kretv_Krakxt
+			eq.signal(298223,2); -- Unlock Doors
+		end
+	elseif (e.timer == "tenae") then
+		e.self:CastSpell(eq.ChooseRandom(889, 887, 751, 888),e.self:GetTarget():GetID());
+	elseif (e.timer == "check") then
 		local instance_id = eq.get_zone_instance_id();
 		e.self:ForeachHateList(
-		  function(ent, hate, damage, frenzy)
-			if(ent:IsClient() and ent:GetX() < 99 or ent:GetX() > 245 or ent:GetY() < 192 or ent:GetY() > 297) then
-			  local currclient=ent:CastToClient();
-				--e.self:Shout("You will not evade me " .. currclient:GetName())
-				currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-				currclient:Message(5,"Pixtt Kretv Krakxt says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+			function(ent, hate, damage, frenzy)
+				if(ent:IsClient() and ent:GetX() < 99 or ent:GetX() > 245 or ent:GetY() < 192 or ent:GetY() > 297) then
+					local currclient=ent:CastToClient();
+					--e.self:Shout("You will not evade me " .. currclient:GetName())
+					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
+					currclient:Message(5,"Pixtt Kretv Krakxt says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+				end
 			end
-		  end
 		);
-  end
+	end
 end
 
 function Spawn_Hatchlings(number, x, y, z, h)
-  hatchlings_spawned = number;
-  hatchlings_killed = 0;
+	hatchlings_spawned = number;
+	hatchlings_killed = 0;
 
-  eq.spawn2(298048,0,0,x+15, y+15, z, h); -- NPC: an_ikaav_hatchling
-  eq.spawn2(298048,0,0,x+15, y-15, z, h); -- NPC: an_ikaav_hatchling
-  eq.spawn2(298048,0,0,x-15, y-15, z, h); -- NPC: an_ikaav_hatchling
+	eq.spawn2(298048,0,0,x+15, y+15, z, h); -- NPC: an_ikaav_hatchling
+	eq.spawn2(298048,0,0,x+15, y-15, z, h); -- NPC: an_ikaav_hatchling
+	eq.spawn2(298048,0,0,x-15, y-15, z, h); -- NPC: an_ikaav_hatchling
 
-  if (number >= 4) then
-    eq.spawn2(298048,0,0,x-15, y+15, z, h); -- NPC: an_ikaav_hatchling
-  end
-
-  if (number >= 5) then
-    eq.spawn2(298048,0,0,x+7, y+15, z, h); -- NPC: an_ikaav_hatchling
-  end
-  if (number >= 6) then
-    eq.spawn2(298048,0,0,x+7, y+7, z, h); -- NPC: an_ikaav_hatchling
-  end
-  if (number >= 7) then
-    eq.spawn2(298048,0,0,x, y, z, h); -- NPC: an_ikaav_hatchling
-  end
+	if (number >= 4) then
+		eq.spawn2(298048,0,0,x-15, y+15, z, h); -- NPC: an_ikaav_hatchling
+	end
+	if (number >= 5) then
+		eq.spawn2(298048,0,0,x+7, y+15, z, h); -- NPC: an_ikaav_hatchling
+	end
+	if (number >= 6) then
+		eq.spawn2(298048,0,0,x+7, y+7, z, h); -- NPC: an_ikaav_hatchling
+	end
+	if (number >= 7) then
+		eq.spawn2(298048,0,0,x, y, z, h); -- NPC: an_ikaav_hatchling
+	end
 end
 
 function PKK_Hp(e)
-  PKK_hitpoints = e.hp_event;
-  if (e.hp_event == 90) then
-    eq.zone_emote(13,"Ha ha ha, you fools thought you could overpower me. You are nothing but food for my offspring. Come my children, strike them down and suck the marrow from their bones. Kretv's body falls to the ground -- a lifeless husk freeing the hatchlings within.");
-eq.set_timer("check", 1 * 1000);
-    eq.get_entity_list():FindDoor(5):SetLockPick(-1);
-    
-    eq.depop();
-    eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
-    eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
-
-    Spawn_Hatchlings(4, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-  elseif (e.hp_event == 70) then
-    eq.zone_emote(13,"Your efforts shall fail no matter how great. This is a reality you shall soon see as your vile existence ceases and my brood consumes your remains.");
-
-    eq.depop();
-    Spawn_Hatchlings(5, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-    eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
-
-    eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
-    eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
-  elseif (e.hp_event == 50) then
-    eq.zone_emote(13,"You show surprising strength and conviction, but you will not get any further. The time has come for you to be destroyed.");
-
-    eq.depop();
-    Spawn_Hatchlings(6, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-    eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
-
-    eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
-    eq.spawn2(298046, 95, 0, 116.0, 206.0, -7.0, 162); -- NPC: Reflection_of_Kretv_Krakxt
-    eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
-  elseif (e.hp_event == 30) then
-    eq.zone_emote(13,"My resolve is waning but I shall fight you to the very last breath. The commander looks down upon weaklings in his ranks and the ikaav are not ones to indulge in it.");
-
-
-    eq.depop();
-    Spawn_Hatchlings(7, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-    eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
-
-    eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
-    eq.spawn2(298046, 95, 0, 116.0, 206.0, -7.0, 162); -- NPC: Reflection_of_Kretv_Krakxt
-    eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
-    eq.spawn2(298146, 96, 0, 227.0, 284.0, -6.0, 315.0); -- needs_heading_validation
-  elseif (e.hp_event == 10) then
-    eq.zone_emote(13,"The end is inevitable, but if I must be defeated, some of you will join me in the afterlife.");
-    Spawn_Hatchlings(3, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-    e.self:SetSpecialAbility(SpecialAbility.rampage, 0); -- turn off single rampage
+	PKK_hitpoints = e.hp_event;
+	if (e.hp_event == 90) then
+		eq.zone_emote(13,"Ha ha ha, you fools thought you could overpower me. You are nothing but food for my offspring. Come my children, strike them down and suck the marrow from their bones. Kretv's body falls to the ground -- a lifeless husk freeing the hatchlings within.");
+		eq.set_timer("check", 1 * 1000);
+		eq.signal(298223,1); -- Lock Doors
+		eq.depop();
+		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
+		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
+		Spawn_Hatchlings(4, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
+	elseif (e.hp_event == 70) then
+		eq.zone_emote(13,"Your efforts shall fail no matter how great. This is a reality you shall soon see as your vile existence ceases and my brood consumes your remains.");
+		eq.depop();
+		Spawn_Hatchlings(5, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
+		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
+		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
+		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
+	elseif (e.hp_event == 50) then
+		eq.zone_emote(13,"You show surprising strength and conviction, but you will not get any further. The time has come for you to be destroyed.");
+		eq.depop();
+		Spawn_Hatchlings(6, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
+		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
+		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
+		eq.spawn2(298046, 95, 0, 116.0, 206.0, -7.0, 162); -- NPC: Reflection_of_Kretv_Krakxt
+		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
+	elseif (e.hp_event == 30) then
+		eq.zone_emote(13,"My resolve is waning but I shall fight you to the very last breath. The commander looks down upon weaklings in his ranks and the ikaav are not ones to indulge in it.");
+		eq.depop();
+		Spawn_Hatchlings(7, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
+		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
+		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
+		eq.spawn2(298046, 95, 0, 116.0, 206.0, -7.0, 162); -- NPC: Reflection_of_Kretv_Krakxt
+		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
+		eq.spawn2(298146, 96, 0, 227.0, 284.0, -6.0, 315.0); -- needs_heading_validation
+	elseif (e.hp_event == 10) then
+		eq.zone_emote(13,"The end is inevitable, but if I must be defeated, some of you will join me in the afterlife.");
+		Spawn_Hatchlings(3, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 0); -- turn off single rampage
 		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1); -- turn aoe ramp on
 		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 50); -- 50% mitigated aoe ramp dmg
-    e.self:CastSpell(eq.ChooseRandom(889, 887, 751, 888),e.self:GetTarget():GetID());
-    eq.set_timer("tenae", 12 * 1000);
-  end
+		e.self:CastSpell(eq.ChooseRandom(889, 887, 751, 888),e.self:GetTarget():GetID());
+		eq.set_timer("tenae", 12 * 1000);
+	end
 end
 
 function PKK_Hatchling_Death(e)
-  hatchlings_killed = hatchlings_killed + 1;
-  -- the events at 10 don't want to do extra hatchling stuff
-  if ( hatchlings_killed >= hatchlings_spawned and PKK_hitpoints ~= 10 ) then
-    eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378); -- NPC: Pixtt_Kretv_Krakxt
-    eq.signal(298203, 1); -- NPC: Reflection_of_Kretv_Krakxt
-    eq.signal(298204, 1); -- NPC: Reflection_of_Kretv_Krakxt
-    eq.signal(298203, 1); -- NPC: Reflection_of_Kretv_Krakxt
-    eq.signal(298046, 1); -- NPC: Reflection_of_Kretv_Krakxt
-    eq.signal(298146, 1); -- NPC: Reflection_of_Kretv_Krakxt
-  end
-  e.self:Emote("black blood spills on the floor");
+	hatchlings_killed = hatchlings_killed + 1;
+	-- the events at 10 don't want to do extra hatchling stuff
+	if ( hatchlings_killed >= hatchlings_spawned and PKK_hitpoints ~= 10 ) then
+		eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378); -- NPC: Pixtt_Kretv_Krakxt
+		eq.signal(298203, 1); -- NPC: Reflection_of_Kretv_Krakxt
+		eq.signal(298204, 1); -- NPC: Reflection_of_Kretv_Krakxt
+		eq.signal(298203, 1); -- NPC: Reflection_of_Kretv_Krakxt
+		eq.signal(298046, 1); -- NPC: Reflection_of_Kretv_Krakxt
+		eq.signal(298146, 1); -- NPC: Reflection_of_Kretv_Krakxt
+	end
+	e.self:Emote("black blood spills on the floor");
 end
 
 function PKK_Hatchling_Spawn(e)
@@ -248,86 +168,82 @@ function PKK_Hatchling_Spawn(e)
 end
 
 function PKK_Roaming_Caster_One_Spawn(e)
-  eq.start(93);
-  CastOnRandom(e.self, 889); -- Delusional Visions
-  eq.set_timer('snake1', 30000);
+	eq.start(93);
+	CastOnRandom(e.self, 889); -- Delusional Visions
+	eq.set_timer('snake1', 30000);
 end
 
 function PKK_Roaming_Caster_Two_Spawn(e)
-  eq.start(94);
-  CastOnRandom(e.self, 887); -- Aura of Fatigue
-  eq.set_timer('snake1', 30000);
+	eq.start(94);
+	CastOnRandom(e.self, 887); -- Aura of Fatigue
+	eq.set_timer('snake1', 30000);
 end
 
 function PKK_Roaming_Caster_Three_Spawn(e)
-  eq.start(95);
-  CastOnRandom(e.self, 751); -- Ikaav's Venom
-  eq.set_timer('snake1', 30000);
+	eq.start(95);
+	CastOnRandom(e.self, 751); -- Ikaav's Venom
+	eq.set_timer('snake1', 30000);
 end
 
 function PKK_Roaming_Caster_Spawn(e)
-  eq.start(96);
-  CastOnRandom(e.self, 888); -- Wrath of the Ikaav
-  eq.set_timer('snake1', 30000);
+	eq.start(96);
+	CastOnRandom(e.self, 888); -- Wrath of the Ikaav
+	eq.set_timer('snake1', 30000);
 end
 
 function CastOnRandom(caster, spell)
-  local client = eq.get_entity_list():GetRandomClient(162, 241, -7, 5000);
-  caster:DoAnim(44);
+	local client = eq.get_entity_list():GetRandomClient(162, 241, -7, 5000);
+	caster:DoAnim(44);
 
-  caster:CastSpell(spell, client:GetID());
+	caster:CastSpell(spell, client:GetID());
 end
 
 function PKK_Roaming_Caster_One_Timer(e)
-  CastOnRandom(e.self, 889); -- Delusional Visions
+	CastOnRandom(e.self, 889); -- Delusional Visions
 end
 
 function PKK_Roaming_Caster_Two_Timer(e)
-  CastOnRandom(e.self, 887); -- Aura of Fatigue
+	CastOnRandom(e.self, 887); -- Aura of Fatigue
 end
 
 function PKK_Roaming_Caster_Three_Timer(e)
-  CastOnRandom(e.self, 751); -- Ikaav's Venom
+	CastOnRandom(e.self, 751); -- Ikaav's Venom
 end
 
 function PKK_Roaming_Caster_Four_Timer(e)
-  CastOnRandom(e.self, 888); -- Wrath of the Ikaav
+	CastOnRandom(e.self, 888); -- Wrath of the Ikaav
 end
 
 function PKK_Roaming_Caster_Signal(e)
-  eq.depop();
+	eq.depop();
 end
 
 function event_encounter_load(e)
-  eq.register_npc_event('pkk', Event.spawn,          298201, PKK_Spawn);
-  eq.register_npc_event('pkk', Event.combat,         298201, PKK_Combat);
-  eq.register_npc_event('pkk', Event.hp,             298201, PKK_Hp);
-  eq.register_npc_event('pkk', Event.timer,          298201, PKK_Timer);
-  eq.register_npc_event('pkk', Event.death_complete, 298201, PKK_Death);
+	eq.register_npc_event('pkk', Event.spawn,          298201, PKK_Spawn);
+	eq.register_npc_event('pkk', Event.combat,         298201, PKK_Combat);
+	eq.register_npc_event('pkk', Event.hp,             298201, PKK_Hp);
+	eq.register_npc_event('pkk', Event.timer,          298201, PKK_Timer);
+	eq.register_npc_event('pkk', Event.death_complete, 298201, PKK_Death);
 
-  eq.register_npc_event('pkk', Event.death_complete, 298048, PKK_Hatchling_Death);
-eq.register_npc_event('pkk', Event.spawn, 298048, PKK_Hatchling_Spawn);
+	eq.register_npc_event('pkk', Event.death_complete, 298048, PKK_Hatchling_Death);
+	eq.register_npc_event('pkk', Event.spawn, 298048, PKK_Hatchling_Spawn);
 
-  eq.register_npc_event('pkk', Event.spawn,          298047, PKK_Husk_Spawn);
-  eq.register_npc_event('pkk', Event.timer,          298047, PKK_Timer); -- Reusing PKK Timer function, should be safe
+	eq.register_npc_event('pkk', Event.spawn,          298047, PKK_Husk_Spawn);
+	eq.register_npc_event('pkk', Event.timer,          298047, PKK_Timer); -- Reusing PKK Timer function, should be safe
 
-  eq.register_npc_event('pkk', Event.spawn,          298204, PKK_Roaming_Caster_One_Spawn);
-  eq.register_npc_event('pkk', Event.timer,          298204, PKK_Roaming_Caster_One_Timer);
-  eq.register_npc_event('pkk', Event.signal,         298204, PKK_Roaming_Caster_Signal);
+	eq.register_npc_event('pkk', Event.spawn,          298204, PKK_Roaming_Caster_One_Spawn);
+	eq.register_npc_event('pkk', Event.timer,          298204, PKK_Roaming_Caster_One_Timer);
+	eq.register_npc_event('pkk', Event.signal,         298204, PKK_Roaming_Caster_Signal);
 
-  eq.register_npc_event('pkk', Event.spawn,          298203, PKK_Roaming_Caster_Two_Spawn);
-  eq.register_npc_event('pkk', Event.timer,          298203, PKK_Roaming_Caster_Two_Timer);
-  eq.register_npc_event('pkk', Event.signal,         298203, PKK_Roaming_Caster_Signal);
+	eq.register_npc_event('pkk', Event.spawn,          298203, PKK_Roaming_Caster_Two_Spawn);
+	eq.register_npc_event('pkk', Event.timer,          298203, PKK_Roaming_Caster_Two_Timer);
+	eq.register_npc_event('pkk', Event.signal,         298203, PKK_Roaming_Caster_Signal);
 
-  eq.register_npc_event('pkk', Event.spawn,          298046, PKK_Roaming_Caster_Three_Spawn);
-  eq.register_npc_event('pkk', Event.timer,          298046, PKK_Roaming_Caster_Three_Timer);
-  eq.register_npc_event('pkk', Event.signal,         298046, PKK_Roaming_Caster_Signal);
+	eq.register_npc_event('pkk', Event.spawn,          298046, PKK_Roaming_Caster_Three_Spawn);
+	eq.register_npc_event('pkk', Event.timer,          298046, PKK_Roaming_Caster_Three_Timer);
+	eq.register_npc_event('pkk', Event.signal,         298046, PKK_Roaming_Caster_Signal);
 
-  eq.register_npc_event('pkk', Event.spawn,          298146, PKK_Roaming_Caster_Four_Spawn);
-  eq.register_npc_event('pkk', Event.timer,          298146, PKK_Roaming_Caster_Four_Timer);
-  eq.register_npc_event('pkk', Event.signal,         298146, PKK_Roaming_Caster_Signal);
-end
-
-function event_encounter_unload(e)
-
+	eq.register_npc_event('pkk', Event.spawn,          298146, PKK_Roaming_Caster_Four_Spawn);
+	eq.register_npc_event('pkk', Event.timer,          298146, PKK_Roaming_Caster_Four_Timer);
+	eq.register_npc_event('pkk', Event.signal,         298146, PKK_Roaming_Caster_Signal);
 end

--- a/tacvi/encounters/pkk.lua
+++ b/tacvi/encounters/pkk.lua
@@ -73,7 +73,7 @@ function PKK_Timer(e)
 					local currclient=ent:CastToClient();
 					--e.self:Shout("You will not evade me " .. currclient:GetName())
 					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-					currclient:Message(5,"Pixtt Kretv Krakxt says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+					currclient:Message(MT.Magenta,"Pixtt Kretv Krakxt says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
 				end
 			end
 		);
@@ -105,7 +105,7 @@ end
 function PKK_Hp(e)
 	PKK_hitpoints = e.hp_event;
 	if (e.hp_event == 90) then
-		eq.zone_emote(13,"Ha ha ha, you fools thought you could overpower me. You are nothing but food for my offspring. Come my children, strike them down and suck the marrow from their bones. Kretv's body falls to the ground -- a lifeless husk freeing the hatchlings within.");
+		eq.zone_emote(MT.Red,"Ha ha ha, you fools thought you could overpower me. You are nothing but food for my offspring. Come my children, strike them down and suck the marrow from their bones. Kretv's body falls to the ground -- a lifeless husk freeing the hatchlings within.");
 		eq.set_timer("check", 1 * 1000);
 		eq.signal(298223,1); -- Lock Doors
 		eq.depop();
@@ -113,14 +113,14 @@ function PKK_Hp(e)
 		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
 		Spawn_Hatchlings(4, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
 	elseif (e.hp_event == 70) then
-		eq.zone_emote(13,"Your efforts shall fail no matter how great. This is a reality you shall soon see as your vile existence ceases and my brood consumes your remains.");
+		eq.zone_emote(MT.Red,"Your efforts shall fail no matter how great. This is a reality you shall soon see as your vile existence ceases and my brood consumes your remains.");
 		eq.depop();
 		Spawn_Hatchlings(5, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
 		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
 		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
 		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
 	elseif (e.hp_event == 50) then
-		eq.zone_emote(13,"You show surprising strength and conviction, but you will not get any further. The time has come for you to be destroyed.");
+		eq.zone_emote(MT.Red,"You show surprising strength and conviction, but you will not get any further. The time has come for you to be destroyed.");
 		eq.depop();
 		Spawn_Hatchlings(6, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
 		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
@@ -128,7 +128,7 @@ function PKK_Hp(e)
 		eq.spawn2(298046, 95, 0, 116.0, 206.0, -7.0, 162); -- NPC: Reflection_of_Kretv_Krakxt
 		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
 	elseif (e.hp_event == 30) then
-		eq.zone_emote(13,"My resolve is waning but I shall fight you to the very last breath. The commander looks down upon weaklings in his ranks and the ikaav are not ones to indulge in it.");
+		eq.zone_emote(MT.Red,"My resolve is waning but I shall fight you to the very last breath. The commander looks down upon weaklings in his ranks and the ikaav are not ones to indulge in it.");
 		eq.depop();
 		Spawn_Hatchlings(7, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
 		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
@@ -137,7 +137,7 @@ function PKK_Hp(e)
 		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
 		eq.spawn2(298146, 96, 0, 227.0, 284.0, -6.0, 315.0); -- needs_heading_validation
 	elseif (e.hp_event == 10) then
-		eq.zone_emote(13,"The end is inevitable, but if I must be defeated, some of you will join me in the afterlife.");
+		eq.zone_emote(MT.Red,"The end is inevitable, but if I must be defeated, some of you will join me in the afterlife.");
 		Spawn_Hatchlings(3, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
 		e.self:SetSpecialAbility(SpecialAbility.rampage, 0); -- turn off single rampage
 		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1); -- turn aoe ramp on

--- a/tacvi/encounters/prt.lua
+++ b/tacvi/encounters/prt.lua
@@ -1,192 +1,176 @@
-
 local construct = 0;
 local golems_spawn = false;
----
--- @param NPC#event_spawn e
+
 function PRT_Spawn(e)
-  e.self:ModSkillDmgTaken(1, -30); -- 1h slashing
-  e.self:ModSkillDmgTaken(3, -30); -- 2h slashing
-e.self:ModSkillDmgTaken(7, -25); -- archery
-  --spawn the two starting golems
-  
-  eq.unique_spawn(298002, 0, 0, 229.0, -572.0, -3.25, 384):SetAppearance(3); -- NPC: a_corrupted_construct (ramp)
-	
-  eq.unique_spawn(298025, 0, 0, 225.0, -600.0, -3.25, 410):SetAppearance(3); -- NPC: a_corrupted_construct (flurry)
+	e.self:ModSkillDmgTaken(1, -30); -- 1h slashing
+	e.self:ModSkillDmgTaken(3, -30); -- 2h slashing
+	e.self:ModSkillDmgTaken(7, -25); -- archery
+	--spawn the two starting golems
+	eq.unique_spawn(298002, 0, 0, 229.0, -572.0, -3.25, 384):SetAppearance(3); -- NPC: a_corrupted_construct (ramp)
+	eq.unique_spawn(298026, 0, 0, 225.0, -600.0, -3.25, 410):SetAppearance(3); -- NPC: a_corrupted_construct (flurry)
 
-  eq.set_next_hp_event(90)
-  golems_spawn = false;
-construct = 0;
-
+	eq.set_next_hp_event(90)
+	golems_spawn = false;
+	construct = 0;
 end
 
 function PRT_Combat(e)
-  if (e.joined == true) then
-    e.self:Say("You shall regret trespassing into my chambers. Rise my minions and show them how well I have learned to use the power of this land's creatures. Destroy them all. Leave only enough to feed the hounds")
-    
-    eq.stop_timer('wipecheck');
-    
-    if (golems_spawn == true) then
-      eq.set_timer("SpawnGolem", 6 * 1000);
-    end
-  else
-    -- Wipe stuff
-    
-    eq.set_timer('wipecheck', 30 * 1000);
-
-    eq.stop_timer("SpawnGolem");
-    eq.stop_timer('VenomAE');
-    eq.stop_timer('Delusional');
-  end
+	if (e.joined == true) then
+		e.self:Say("You shall regret trespassing into my chambers. Rise my minions and show them how well I have learned to use the power of this land's creatures. Destroy them all. Leave only enough to feed the hounds")
+		eq.stop_timer('wipecheck');
+		
+		eq.signal(298002,1); --a_corrupted_construct remove immunities
+		eq.signal(298026,1); --a_corrupted_construct remove immunities
+		
+		if (golems_spawn == true) then
+			eq.set_timer("SpawnGolem", 6 * 1000);
+		end
+	else
+		-- Wipe stuff
+	
+		eq.signal(298002,2); --a_corrupted_construct add immunities
+		eq.signal(298026,2); --a_corrupted_construct add immunities
+		
+		eq.set_timer('wipecheck', 30 * 1000);
+		eq.stop_timer("SpawnGolem");
+		eq.stop_timer('VenomAE');
+		eq.stop_timer('Delusional');
+	end
 end
 
 function PRT_HP(e)
-  if (e.hp_event == 90) then
-    --lock door behind her
-    eq.get_entity_list():FindDoor(23):SetLockPick(-1)
-    eq.set_next_hp_event(50)
-	eq.set_timer("check", 1 * 1000); -- start checking for clients outside room
-	eq.zone_emote(0,"Riel raises her hands to the sky and laughs as the door behind you seals itself.");
-
-  elseif (e.hp_event == 50) then
-    --add flurry, reduce atk delay
-    e.self:ModifyNPCStat("attack_delay","12");
-    e.self:SetSpecialAbility(SpecialAbility.flurry, 1)
-    eq.set_timer("Delusional", 30 * 1000)
-    e.self:Say("So it seems you are not so easily defeated after all. I am through toying with you fools. Prepare for the reality of death.' Riel's body begins to speed up as her attacks become increasingly vicious")
-    
-    eq.set_next_hp_event(30)
-
-  elseif (e.hp_event == 30) then
-    --start golem waves, first spawn is 4, next are based on hp (4 <=30%, 8 <=20%, 12 <=10%)
-    eq.set_timer("SpawnGolem", 6 * 1000)
-    e.self:Say("You and your friends are starting to annoy me.  Come forth my little experiments.  Choose one of these fools and show them the surprise you have waiting.");
-    --spawn 4 mini golems
-    --an_unstable_construct (298045)
-    eq.set_next_hp_event(25)
-
-    golems_spawn = true;
-
-  elseif (e.hp_event == 25) then
-    --add Ikaav's Venom AE
-    eq.set_timer("VenomAE", 30000)
-    e.self:CastSpell(751,e.self:GetID())
-    eq.set_next_hp_event(10)
-
-  elseif (e.hp_event == 10) then
-    -- At approximately 10% health, she increases her attack speed and begins flurrying much more (every round)
-    e.self:SetSpecialAbilityParam(SpecialAbility.flurry, 0, 100)
-    
-    e.self:Say("That's it!  You have past the point of being bothersome. I grow weary of this encounter. It is time for it to end.")
-
-  end
+	if (e.hp_event == 90) then
+		--lock door behind her
+		eq.signal(298223,1); -- Lock Doors
+		eq.set_next_hp_event(50)
+		eq.set_timer("check", 1 * 1000); -- start checking for clients outside room
+		eq.zone_emote(0,"Riel raises her hands to the sky and laughs as the door behind you seals itself.");
+	elseif (e.hp_event == 50) then
+		--add flurry, reduce atk delay
+		e.self:ModifyNPCStat("attack_delay","12");
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 1)
+		eq.set_timer("Delusional", 30 * 1000)
+		e.self:Say("So it seems you are not so easily defeated after all. I am through toying with you fools. Prepare for the reality of death.' Riel's body begins to speed up as her attacks become increasingly vicious")
+		eq.set_next_hp_event(30)
+	elseif (e.hp_event == 30) then
+		--start golem waves, first spawn is 4, next are based on hp (4 <=30%, 8 <=20%, 12 <=10%)
+		eq.set_timer("SpawnGolem", 6 * 1000)
+		e.self:Say("You and your friends are starting to annoy me.  Come forth my little experiments.  Choose one of these fools and show them the surprise you have waiting.");
+		--spawn 4 mini golems
+		--an_unstable_construct (298045)
+		eq.set_next_hp_event(25)
+		golems_spawn = true;
+	elseif (e.hp_event == 25) then
+		--add Ikaav's Venom AE
+		eq.set_timer("VenomAE", 30000)
+		e.self:CastSpell(751,e.self:GetID())
+		eq.set_next_hp_event(10)
+	elseif (e.hp_event == 10) then
+		-- At approximately 10% health, she increases her attack speed and begins flurrying much more (every round)
+		e.self:SetSpecialAbilityParam(SpecialAbility.flurry, 0, 100)
+		e.self:Say("That's it!  You have past the point of being bothersome. I grow weary of this encounter. It is time for it to end.")
+	end
 end
 
 function PRT_Timer(e)
-  if (e.timer == "Delusional") then
-    --Delusional Vision single target DD/Drunk whole fight
-    e.self:SpellFinished(889, e.self:GetHateTop()) --CastToClient? --no need unless using client-based methods
-  elseif (e.timer == "VenomAE") then
-    --Ikaav's Venom 751
-    e.self:CastSpell(751,e.self:GetID())
-  elseif(e.timer=="SpawnGolem") then
-        --eq.stop_timer("SpawnGolem");
-  	if (e.self:GetHPRatio() >= 20) then
-            if ( construct < 12 ) then
-                
-	            local rng = math.random(4, 4);
-	            local spawned = 0;
-	
-	            for i = construct+1, 12 do
-				    eq.spawn2(298045, 0, 0, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0);
-		
-				    spawned = spawned + 1;
-				if ( spawned == rng ) then
-					break;
+	if (e.timer == "Delusional") then
+		--Delusional Vision single target DD/Drunk whole fight
+		e.self:SpellFinished(889, e.self:GetHateTop()) --CastToClient? --no need unless using client-based methods
+	elseif (e.timer == "VenomAE") then
+		--Ikaav's Venom 751
+		e.self:CastSpell(751,e.self:GetID())
+	elseif(e.timer=="SpawnGolem") then
+		local construct_locs = { 
+			[1] = { 189.61, -586.55, -8.55,128}, 
+			[2] = { 180.10, -569.03, -8.55,380},
+			[3] = { 180.10, -609.61, -8.55,128}, 
+			[4] = { 107.81, -586.55, -8.55,128}
+		};
+		--eq.stop_timer("SpawnGolem");
+		if (e.self:GetHPRatio() >= 20) then
+			if ( construct < 12 ) then	
+				local rng = math.random(4, 4);
+				local spawned = 0;
+
+				for i = construct+1, 12 do
+					local ran = math.random(1,4);
+					eq.spawn2(298045, 0, 0, unpack(construct_locs[ran]));
+					spawned = spawned + 1;
+					if ( spawned == rng ) then
+						break;
+					end
 				end
+				construct = construct + spawned;
 			end
-			construct = construct + spawned;
-		end
-	elseif (e.self:GetHPRatio() > 10 and e.self:GetHPRatio() < 20) then
-		if ( construct < 12 ) then
-                
-	            local rng = math.random(8, 8);
-	            local spawned = 0;
+		elseif (e.self:GetHPRatio() > 10 and e.self:GetHPRatio() < 20) then
+			if ( construct < 12 ) then	
+				local rng = math.random(8, 8);
+				local spawned = 0;
 	
-	            for i = construct+1, 12 do
-				    eq.spawn2(298045, 0, 0, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0);
-		
-				    spawned = spawned + 1;
-				if ( spawned == rng ) then
-					break;
+				for i = construct+1, 12 do
+					local ran = math.random(1,4);
+					eq.spawn2(298045, 0, 0, unpack(construct_locs[ran]));
+					spawned = spawned + 1;
+					if ( spawned == rng ) then
+						break;
+					end
 				end
+				construct = construct + spawned;
 			end
-			construct = construct + spawned;
-		end
-		eq.set_timer("SpawnGolem", 4 * 1000) --speed up timer
-	elseif (e.self:GetHPRatio() < 10) then
-		if ( construct < 12 ) then
-                
-	            local rng = math.random(12, 12);
-	            local spawned = 0;
+			eq.set_timer("SpawnGolem", 4 * 1000) --speed up timer
+		elseif (e.self:GetHPRatio() < 10) then
+			if ( construct < 12 ) then		
+				local rng = math.random(12, 12);
+				local spawned = 0;
 	
-	            for i = construct+1, 12 do
-				    eq.spawn2(298045, 0, 0, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0);
-		
-				    spawned = spawned + 1;
-				if ( spawned == rng ) then
-					break;
+				for i = construct+1, 12 do
+					local ran = math.random(1,4);
+					eq.spawn2(298045, 0, 0, unpack(construct_locs[ran]));
+					spawned = spawned + 1;
+					if ( spawned == rng ) then
+						break;
+					end
 				end
+				construct = construct + spawned;
 			end
-			construct = construct + spawned;
+			eq.set_timer("SpawnGolem", 2 * 1000) --speed up timer
 		end
-		eq.set_timer("SpawnGolem", 2 * 1000) --speed up timer
-	end
-  elseif (e.timer == 'wipecheck') then
-    --eq.depop_all(298045);
-    --eq.depop_all(298002);
-    --eq.depop();
-    --eq.spawn2(298032, 0, 0, 202.0, -586.0, -4.125, 380); -- NPC: Pixtt_Riel_Tavas
-	eq.stop_timer('wipecheck');
-		
-	e.self:SetHP(e.self:GetMaxHP())
-	eq.unique_spawn(298002, 0, 0, 229.0, -572.0, -3.25, 384):SetAppearance(3); -- NPC: a_corrupted_construct (ramp)
-  	eq.unique_spawn(298025, 0, 0, 225.0, -600.0, -3.25, 410):SetAppearance(3); -- NPC: a_corrupted_construct (flurry)
-	
-	eq.depop_all(298045);
-		
-  	eq.set_next_hp_event(90)
-  	golems_spawn = false;
-	construct = 0;
-		
-	eq.get_entity_list():FindDoor(23):SetLockPick(0) --only unlock door after wipe reset timer is met
-elseif (e.timer == "check") then
-		
+	elseif (e.timer == 'wipecheck') then
+		--eq.depop_all(298045);
+		--eq.depop_all(298002);
+		--eq.depop();
+		--eq.spawn2(298032, 0, 0, 202.0, -586.0, -4.125, 380); -- NPC: Pixtt_Riel_Tavas
+		eq.stop_timer('wipecheck');
+		e.self:SetHP(e.self:GetMaxHP())
+		eq.unique_spawn(298002, 0, 0, 229.0, -572.0, -3.25, 384):SetAppearance(3); -- NPC: a_corrupted_construct (ramp)
+		eq.unique_spawn(298026, 0, 0, 225.0, -600.0, -3.25, 410):SetAppearance(3); -- NPC: a_corrupted_construct (flurry)
+		eq.depop_all(298045);
+		eq.set_next_hp_event(90)
+		golems_spawn = false;
+		construct = 0;		
+		eq.signal(298223,2); -- Unlock Doors
+	elseif (e.timer == "check") then
 		local instance_id = eq.get_zone_instance_id();
 		e.self:ForeachHateList(
-		  function(ent, hate, damage, frenzy)
-			if(ent:IsClient() and ent:GetX() < 100 or ent:GetX() > 244 or ent:GetY() > -535 or ent:GetY() < -636) then
-			  local currclient=ent:CastToClient();
-				--e.self:Shout("You will not evade me " .. currclient:GetName())
-				currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-				currclient:Message(5,"Pixtt Riel Tavas says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+			function(ent, hate, damage, frenzy)
+				if(ent:IsClient() and ent:GetX() < 100 or ent:GetX() > 244 or ent:GetY() > -535 or ent:GetY() < -636) then
+					local currclient=ent:CastToClient();
+					--e.self:Shout("You will not evade me " .. currclient:GetName())
+					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
+					currclient:Message(5,"Pixtt Riel Tavas says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+				end
 			end
-		  end
 		);
-  end
+	end
 end
 
 function PRT_Death(e)
-  e.self:Emote("'s body falls to the stone floor in a puddle of blackened blood. You step back as she slashes one last time, connecting with nothing but the stale air of the room. 'This is not over. My commander will destroy you for this and when he does I hope it is my power he is weilding'")
-  eq.zone_emote(15, "With the death of the great beast, the seals on the doors fade away. Your path is now clear.")
+	e.self:Emote("'s body falls to the stone floor in a puddle of blackened blood. You step back as she slashes one last time, connecting with nothing but the stale air of the room. 'This is not over. My commander will destroy you for this and when he does I hope it is my power he is weilding'")
+	eq.zone_emote(15, "With the death of the great beast, the seals on the doors fade away. Your path is now clear.")
 
-  -- Open doors
-  -- Door before her
-  eq.get_entity_list():FindDoor(23):SetLockPick(0)
-  -- Doors after her
-  eq.get_entity_list():FindDoor(22):SetLockPick(0)
-  eq.get_entity_list():FindDoor(17):SetLockPick(0)
-
-  eq.signal(298223, 298032); -- NPC: zone_status
+	-- Open doors
+	eq.signal(298223, 298032); -- NPC: zone_status
+	eq.signal(298223,2,1000); -- Unlock Doors
 end
 
 function PRT_Signal(e)
@@ -194,74 +178,77 @@ function PRT_Signal(e)
 		construct = construct - 1; --add dead or mez death
 	end
 end
+
 -- a_corrupted_construct (298002)
 -- Big golem at beginning of Pixtt_Riel_Tavas fight
-
 function Corrupt_Spawn(e)
-  e.self:SetAppearance(3)
-  e.self:ModSkillDmgTaken(1, -25); -- 1h slashing
-  e.self:ModSkillDmgTaken(3, -25); -- 2h slashing
-e.self:ModSkillDmgTaken(0, 10); -- 1h blunt
-e.self:ModSkillDmgTaken(2, 10); -- 2h blunt
-e.self:ModSkillDmgTaken(7, -25); -- archery
+	e.self:SetAppearance(3)
+	e.self:ModSkillDmgTaken(1, -25); -- 1h slashing
+	e.self:ModSkillDmgTaken(3, -25); -- 2h slashing
+	e.self:ModSkillDmgTaken(0, 10); -- 1h blunt
+	e.self:ModSkillDmgTaken(2, 10); -- 2h blunt
+	e.self:ModSkillDmgTaken(7, -25); -- archery
 end
 
 function Corrupt_Death(e)
-  e.self:Emote("The ground trembles as the massive construct falls.")
+	e.self:Emote("The ground trembles as the massive construct falls.")
+end
 
+function Corrupt_Signal(e)
+	if (e.signal == 1) then
+		e.self:SetSpecialAbility(35, 0); --turn off immunity
+		e.self:SetSpecialAbility(24, 0); --turn off anti aggro
+	elseif (e.signal == 2) then
+		e.self:SetSpecialAbility(35, 1); --turn on immunity
+		e.self:SetSpecialAbility(24, 1); --turn on anti aggro
+		e.self:WipeHateList();
+	end
 end
 
 -- an_unstable_construct (298045)
 -- add during Pixtt_Riel_Tavas fight
 -- mini golems that cast a AE DD when they die
-
 function Unstable_Death(e)
-eq.signal(298032,1); --Pixtt_Riel_Tavas (298032) signal to reduce add count	
-	
-  e.self:CastSpell(4661, e.self:GetID()); -- Spell: Cataclysm of Stone
-
+	eq.signal(298032,1); --Pixtt_Riel_Tavas (298032) signal to reduce add count	
+	e.self:CastSpell(4661, e.self:GetID()); -- Spell: Cataclysm of Stone
 end
 
-
-
 function Unstable_Spawn(e)
-  eq.set_timer("mez_check", 1 * 1000); -- 1s check
+	eq.set_timer("mez_check", 1 * 1000); -- 1s check
 end
 
 function Unstable_Timer(e)
-  if e.timer == "mez_check" then
-    if e.self:IsMezzed() then
-      eq.stop_timer("mez_check");
-    	eq.set_timer("depop", 30 * 1000); -- depop in 30s
-    end
-elseif e.timer == "depop" then
-	eq.stop_timer("depop");
-		
+	if e.timer == "mez_check" then
+		if e.self:IsMezzed() then
+			eq.stop_timer("mez_check");
+			eq.set_timer("depop", 30 * 1000); -- depop in 30s
+		end
+	elseif e.timer == "depop" then
+		eq.stop_timer("depop");
 		if (eq.get_entity_list():IsMobSpawnedByNpcTypeID(298032) == true) then -- only depops if PRT is alive
 			eq.signal(298032,1); --Pixtt_Riel_Tavas (298032) signal to reduce add count
-		
-		
-			e.self:Emote("ceases its struggles as the energy that brought it to life fades away.");
-			
+			e.self:Emote("ceases its struggles as the energy that brought it to life fades away.");			
 			eq.depop();
 		end
-  end
+	end
 end
 
 function event_encounter_load(e)
-  eq.register_npc_event('prt', Event.spawn,           298032, PRT_Spawn);
-  eq.register_npc_event('prt', Event.combat,          298032, PRT_Combat);
-  eq.register_npc_event('prt', Event.hp,              298032, PRT_HP);
-  eq.register_npc_event('prt', Event.timer,           298032, PRT_Timer);
-  eq.register_npc_event('prt', Event.death_complete,  298032, PRT_Death);
-eq.register_npc_event('prt', Event.signal,           298032, PRT_Signal);
+	eq.register_npc_event('prt', Event.spawn,           298032, PRT_Spawn);
+	eq.register_npc_event('prt', Event.combat,          298032, PRT_Combat);
+	eq.register_npc_event('prt', Event.hp,              298032, PRT_HP);
+	eq.register_npc_event('prt', Event.timer,           298032, PRT_Timer);
+	eq.register_npc_event('prt', Event.death_complete,  298032, PRT_Death);
+	eq.register_npc_event('prt', Event.signal,           298032, PRT_Signal);
 
-  eq.register_npc_event('prt', Event.spawn,           298002, Corrupt_Spawn);
-  eq.register_npc_event('prt', Event.death_complete,  298002, Corrupt_Death);
-eq.register_npc_event('prt', Event.spawn,           298025, Corrupt_Spawn);
-  eq.register_npc_event('prt', Event.death_complete,  298025, Corrupt_Death);
-  
-  eq.register_npc_event('prt', Event.death,           298045, Unstable_Death);
-eq.register_npc_event('prt', Event.spawn,           298045, Unstable_Spawn);
+	eq.register_npc_event('prt', Event.spawn,           298002, Corrupt_Spawn);
+	eq.register_npc_event('prt', Event.death_complete,  298002, Corrupt_Death);
+	eq.register_npc_event('prt', Event.spawn,           298026, Corrupt_Spawn);
+	eq.register_npc_event('prt', Event.death_complete,  298026, Corrupt_Death);
+	eq.register_npc_event('prt', Event.signal,           298002, Corrupt_Signal);
+	eq.register_npc_event('prt', Event.signal,           298026, Corrupt_Signal);
+	
+	eq.register_npc_event('prt', Event.death,           298045, Unstable_Death);
+	eq.register_npc_event('prt', Event.spawn,           298045, Unstable_Spawn);
 	eq.register_npc_event('prt', Event.timer,           298045, Unstable_Timer);
 end

--- a/tacvi/encounters/prt.lua
+++ b/tacvi/encounters/prt.lua
@@ -157,7 +157,7 @@ function PRT_Timer(e)
 					local currclient=ent:CastToClient();
 					--e.self:Shout("You will not evade me " .. currclient:GetName())
 					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-					currclient:Message(5,"Pixtt Riel Tavas says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+					currclient:Message(MT.Magenta,"Pixtt Riel Tavas says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
 				end
 			end
 		);
@@ -166,7 +166,7 @@ end
 
 function PRT_Death(e)
 	e.self:Emote("'s body falls to the stone floor in a puddle of blackened blood. You step back as she slashes one last time, connecting with nothing but the stale air of the room. 'This is not over. My commander will destroy you for this and when he does I hope it is my power he is weilding'")
-	eq.zone_emote(15, "With the death of the great beast, the seals on the doors fade away. Your path is now clear.")
+	eq.zone_emote(MT.Yellow, "With the death of the great beast, the seals on the doors fade away. Your path is now clear.")
 
 	-- Open doors
 	eq.signal(298223, 298032); -- NPC: zone_status

--- a/tacvi/encounters/pxk.lua
+++ b/tacvi/encounters/pxk.lua
@@ -46,7 +46,7 @@ function PXK_Hp(e)
 	if e.hp_event == 90 then
 		--locks door leading into her chamber
 		eq.signal(298223,1); -- Lock Doors
-		eq.zone_emote(13,"Xxeric begins to froth at the mouth as her skin becomes more rigid and her rage begins to grow. You feel a force from behind you as the door is once again sealed.");
+		eq.zone_emote(MT.Red,"Xxeric begins to froth at the mouth as her skin becomes more rigid and her rage begins to grow. You feel a force from behind you as the door is once again sealed.");
 		e.self:SetPseudoRoot(false);
 		e.self:CastedSpellFinished(4729, e.self:GetHateRandom()); -- Spell: Spirit Cleaver
 		eq.set_timer("cleaver", 120 * 1000);
@@ -60,7 +60,7 @@ function PXK_Hp(e)
 		manasipper  = 0;
 		ragehound   = 0;
 	elseif e.hp_event == 70 then
-		eq.zone_emote(13,"The froth around her mouth thickens as she channels the force of her growing rage into each attack, sacrificing her thickened skin.");
+		eq.zone_emote(MT.Red,"The froth around her mouth thickens as she channels the force of her growing rage into each attack, sacrificing her thickened skin.");
 		eq.modify_npc_stat("ac", "604");
 		eq.modify_npc_stat("min_hit", "1300");
 		eq.modify_npc_stat("max_hit", "5945");
@@ -70,7 +70,7 @@ function PXK_Hp(e)
 		eq.set_timer("cleaver", 90 * 1000);
 		eq.set_next_hp_event(50);
 	elseif e.hp_event == 50 then
-		eq.zone_emote(13,"Raising her head to the sky, Xxeric lets out a battle cry that shakes the walls and calls forth a pack of raging ukun hounds. 'Prepare yourself for the afterlife this is the reality of the Mata Muram army.");
+		eq.zone_emote(MT.Red,"Raising her head to the sky, Xxeric lets out a battle cry that shakes the walls and calls forth a pack of raging ukun hounds. 'Prepare yourself for the afterlife this is the reality of the Mata Muram army.");
 		-- she begins casting  Wave of Rage
 		e.self:CastedSpellFinished(4728, e.self:GetHateRandom()); -- Spell: Wave of Rage
 		eq.set_timer("cleaver", 60 * 1000);
@@ -97,7 +97,7 @@ function PXK_Hp(e)
 		e.self:SetHP(e.self:GetMaxHP()*0.40)
 		eq.modify_npc_stat("min_hit", "1245");
 		eq.modify_npc_stat("max_hit", "4665");
-		eq.zone_emote(13,"You may yet have the strength to defeat me but I am not through with you yet. Xxeric's eyes turn blood red as she enters an uncontrollable rage. Focusing on her wounds, she begins to recover some health.");
+		eq.zone_emote(MT.Red,"You may yet have the strength to defeat me but I am not through with you yet. Xxeric's eyes turn blood red as she enters an uncontrollable rage. Focusing on her wounds, she begins to recover some health.");
 	end
 end
 
@@ -116,7 +116,7 @@ function PXK_Timer(e)
 					local currclient=ent:CastToClient();
 					--e.self:Shout("You will not evade me " .. currclient:GetName())
 					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-					currclient:Message(5,"Pixtt Xxeric Kex says, 'Did you think I would let you enter these halls without consequence?");
+					currclient:Message(MT.Magenta,"Pixtt Xxeric Kex says, 'Did you think I would let you enter these halls without consequence?");
 				end
 			end
 		);

--- a/tacvi/encounters/pxk.lua
+++ b/tacvi/encounters/pxk.lua
@@ -1,225 +1,178 @@
-
-local door = 0;
 local entity_list = eq.get_entity_list();
-
 local juxtapincer = 4;
 local lifebleeder = 4;
 local manasipper  = 4;
 local ragehound   = 4;
 
-local inst_id = 0;
-
 function PXK_Spawn(e)
-  e.self:SetPseudoRoot(true);
-  eq.set_next_hp_event(90);
-  eq.get_entity_list():FindDoor(2):SetLockPick(0);
+	e.self:SetPseudoRoot(true);
+	eq.set_next_hp_event(90);
+	eq.signal(298223,2);
 end
 
 function PXK_Death(e)
-  local door = 0;
-  door = entity_list:FindDoor(3);
-  if (door ~= nil) then
-    door:SetLockPick(0);
-  end
-
-  door = entity_list:FindDoor(4);
-  if (door ~= nil) then
-    door:SetLockPick(0);
-  end
-
-  eq.signal(298223, 298039); -- NPC: zone_status
-  eq.get_entity_list():FindDoor(2):SetLockPick(0);
+	eq.signal(298223, 298039); -- NPC: zone_status
+	eq.signal(298223,2,1000); -- Unlock Doors
 end
 
 function PXK_Combat(e)
-  if (e.joined == true) then
-    e.self:Say("Have at you intruder. This is the domain of the commander and only those strong enough to beat me shall pass.");
-  else 
-    -- Wipe mechanics
-    -- Depop adds, repop myself
-    eq.stop_timer("cleaver");
-    eq.stop_timer("rage");
-    eq.stop_timer("check");
-    eq.depop_all(298044);
-    eq.depop_all(298043);
-    eq.depop_all(298042);
-    eq.depop_all(298041);
-    eq.spawn2(298039,0,0,151,-162,-6,385); -- NPC: Pixtt_Xxeric_Kex
-    eq.depop();
+	if (e.joined == true) then
+		e.self:Say("Have at you intruder. This is the domain of the commander and only those strong enough to beat me shall pass.");
+	else 
+		-- Wipe mechanics
+		-- Depop adds, repop myself
+		eq.stop_timer("cleaver");
+		eq.stop_timer("rage");
+		eq.stop_timer("check");
+		eq.depop_all(298044);
+		eq.depop_all(298043);
+		eq.depop_all(298042);
+		eq.depop_all(298041);
+		eq.spawn2(298039,0,0,151,-162,-6,385); -- NPC: Pixtt_Xxeric_Kex
+		eq.depop();
 
-    -- reset the pet event counters in case of a wipe.
-    juxtapincer = 0;
-    lifebleeder = 0;
-    manasipper  = 0;
-    ragehound   = 0;
+		-- reset the pet event counters in case of a wipe.
+		juxtapincer = 0;
+		lifebleeder = 0;
+		manasipper  = 0;
+		ragehound   = 0;
 
-    eq.get_entity_list():FindDoor(2):SetLockPick(0);
-  end
+		eq.signal(298223,2); -- Unlock Doors
+	end
 end
 
 function PXK_Hp(e)
-   --90pct unroot
-   if (e.hp_event == 90) then
-    
-    --locks door leading into her chamber
-      door = entity_list:FindDoor(2);
-      if (door ~= nil) then door:SetLockPick(-1); end
-      eq.zone_emote(13,"Xxeric begins to froth at the mouth as her skin becomes more rigid and her rage begins to grow. You feel a force from behind you as the door is once again sealed.");
-      
-      e.self:SetPseudoRoot(false);
-      e.self:CastedSpellFinished(4729, e.self:GetHateRandom()); -- Spell: Spirit Cleaver
-    
-      eq.set_timer("cleaver", 120 * 1000);
-      
-      eq.set_timer("check", 1 * 1000);
-    
-      eq.modify_npc_stat("ac", "1150");
-      eq.modify_npc_stat("min_hit", "595");
-      eq.modify_npc_stat("max_hit", "4500");
-      eq.set_next_hp_event(70);
-    
-   
-      juxtapincer = 0;
-      lifebleeder = 0;
-      manasipper  = 0;
-      ragehound   = 0;
-   end
-  
-   if (e.hp_event == 70) then
-      eq.zone_emote(13,"The froth around her mouth thickens as she channels the force of her growing rage into each attack, sacrificing her thickened skin.");
-      eq.modify_npc_stat("ac", "604");
-      eq.modify_npc_stat("min_hit", "1300");
-      eq.modify_npc_stat("max_hit", "5945");
-      e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
-      e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
-      e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 15); -- 15 % mitigated dmg
-    
-      eq.set_timer("cleaver", 90 * 1000);
-      eq.set_next_hp_event(50);
-   end
-  
-   -- At 50% you see
-   if (e.hp_event == 50) then
-      eq.zone_emote(13,"Raising her head to the sky, Xxeric lets out a battle cry that shakes the walls and calls forth a pack of raging ukun hounds. 'Prepare yourself for the afterlife this is the reality of the Mata Muram army.");
-      -- she begins casting  Wave of Rage
-      e.self:CastedSpellFinished(4728, e.self:GetHateRandom()); -- Spell: Wave of Rage
-    
-      eq.set_timer("cleaver", 60 * 1000);
-      eq.set_timer("rage", 60 * 1000);
-
-      eq.modify_npc_stat("ac", "900");
-    
-    -- Spawn the Pets
-      eq.spawn2(298044,0,0, 151, -113, -6.87, 314); -- NPC: an_ukun_juxtapincer
-      eq.spawn2(298043,0,0, 151, -218, -6.87, 450); -- NPC: an_ukun_lifebleeder
-      eq.spawn2(298042,0,0,  81, -113, -6.87,  194); -- NPC: an_ukun_manasipper
-      eq.spawn2(298041,0,0,  81, -218, -6.87,  40); -- NPC: an_ukun_ragehound
-
-      eq.set_next_hp_event(30);
-    
-   end
-
-   --Below 30%
-   if (e.hp_event == 30) then
-      --At 30%, she gains some strength:
-      --Emotes at 30% and DPS picks up.
-      eq.modify_npc_stat("min_hit", "1275");
-      eq.modify_npc_stat("max_hit", "5185");
-      eq.modify_npc_stat("ac", "700");
-      e.self:Say("I commend you on your tenacity, infidels. However I am through playing games. Witness the true fighting power of an Ixt Berserker.");
-    
-      eq.set_timer("cleaver", 30 * 1000);
-    
-      eq.set_next_hp_event(10);
-   end
-
-   --10%
-   if (e.hp_event == 10) then
-   --When she hits 10%, she will regenerate to 40% health and strip her debuffs
-      -- Balance of the nameless, strip self debuffs
-      e.self:CastSpell(3230,e.self:GetID()); -- Spell: Balance of the Nameless
-      e.self:SetHP(e.self:GetMaxHP()*0.40)
-      eq.modify_npc_stat("min_hit", "1245");
-      eq.modify_npc_stat("max_hit", "4665");
-      eq.zone_emote(13,"You may yet have the strength to defeat me but I am not through with you yet. Xxeric's eyes turn blood red as she enters an uncontrollable rage. Focusing on her wounds, she begins to recover some health.");
-      
-   end
+	--90pct unroot
+	if e.hp_event == 90 then
+		--locks door leading into her chamber
+		eq.signal(298223,1); -- Lock Doors
+		eq.zone_emote(13,"Xxeric begins to froth at the mouth as her skin becomes more rigid and her rage begins to grow. You feel a force from behind you as the door is once again sealed.");
+		e.self:SetPseudoRoot(false);
+		e.self:CastedSpellFinished(4729, e.self:GetHateRandom()); -- Spell: Spirit Cleaver
+		eq.set_timer("cleaver", 120 * 1000);
+		eq.set_timer("check", 1 * 1000);
+		eq.modify_npc_stat("ac", "1150");
+		eq.modify_npc_stat("min_hit", "595");
+		eq.modify_npc_stat("max_hit", "4500");
+		eq.set_next_hp_event(70);
+		juxtapincer = 0;
+		lifebleeder = 0;
+		manasipper  = 0;
+		ragehound   = 0;
+	elseif e.hp_event == 70 then
+		eq.zone_emote(13,"The froth around her mouth thickens as she channels the force of her growing rage into each attack, sacrificing her thickened skin.");
+		eq.modify_npc_stat("ac", "604");
+		eq.modify_npc_stat("min_hit", "1300");
+		eq.modify_npc_stat("max_hit", "5945");
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
+		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 85); -- 15 % mitigated dmg
+		eq.set_timer("cleaver", 90 * 1000);
+		eq.set_next_hp_event(50);
+	elseif e.hp_event == 50 then
+		eq.zone_emote(13,"Raising her head to the sky, Xxeric lets out a battle cry that shakes the walls and calls forth a pack of raging ukun hounds. 'Prepare yourself for the afterlife this is the reality of the Mata Muram army.");
+		-- she begins casting  Wave of Rage
+		e.self:CastedSpellFinished(4728, e.self:GetHateRandom()); -- Spell: Wave of Rage
+		eq.set_timer("cleaver", 60 * 1000);
+		eq.set_timer("rage", 60 * 1000);
+		eq.modify_npc_stat("ac", "900");
+		-- Spawn the Pets
+		eq.spawn2(298044,0,0, 151, -113, -6.87, 314); -- NPC: an_ukun_juxtapincer
+		eq.spawn2(298043,0,0, 151, -218, -6.87, 450); -- NPC: an_ukun_lifebleeder
+		eq.spawn2(298042,0,0,  81, -113, -6.87,  194); -- NPC: an_ukun_manasipper
+		eq.spawn2(298041,0,0,  81, -218, -6.87,  40); -- NPC: an_ukun_ragehound
+		eq.set_next_hp_event(30);
+	elseif e.hp_event == 30 then
+		eq.modify_npc_stat("min_hit", "1275");
+		eq.modify_npc_stat("max_hit", "5185");
+		eq.modify_npc_stat("ac", "700");
+		e.self:Say("I commend you on your tenacity, infidels. However I am through playing games. Witness the true fighting power of an Ixt Berserker.");
+		-- should this be red zone emote?
+		eq.set_timer("cleaver", 30 * 1000);
+		eq.set_next_hp_event(10);
+	elseif e.hp_event == 10 then
+		-- When she hits 10%, she will regenerate to 40% health and strip her debuffs
+		-- Balance of the nameless, strip self debuffs
+		e.self:CastSpell(3230,e.self:GetID()); -- Spell: Balance of the Nameless
+		e.self:SetHP(e.self:GetMaxHP()*0.40)
+		eq.modify_npc_stat("min_hit", "1245");
+		eq.modify_npc_stat("max_hit", "4665");
+		eq.zone_emote(13,"You may yet have the strength to defeat me but I am not through with you yet. Xxeric's eyes turn blood red as she enters an uncontrollable rage. Focusing on her wounds, she begins to recover some health.");
+	end
 end
 
 function PXK_Timer(e)
-  if (e.timer == "cleaver") then
-    e.self:CastedSpellFinished(4729, e.self:GetHateRandom()); -- Spell: Spirit Cleaver
-  elseif (e.timer == "rage") then
-    e.self:CastedSpellFinished(4728, e.self:GetHateRandom()); -- Spell: Wave of Rage
-  elseif (e.timer == "check") then
+	if e.timer == "cleaver" then
+		e.self:CastedSpellFinished(4729, e.self:GetHateRandom()); -- Spell: Spirit Cleaver
+	elseif e.timer == "rage" then
+		e.self:CastedSpellFinished(4728, e.self:GetHateRandom()); -- Spell: Wave of Rage
+	elseif e.timer == "check" then
 		--local rand = math.random(1,100);
 		--if (rand >= 85) then -- 15 % to cast throw
 		local instance_id = eq.get_zone_instance_id();
 		e.self:ForeachHateList(
-		  function(ent, hate, damage, frenzy)
-			if(ent:IsClient() and ent:GetX() < 49 or ent:GetY() < -243 or ent:GetY() > -86 or ent:GetX() > 195) then
-			  local currclient=ent:CastToClient();
-				--e.self:Shout("You will not evade me " .. currclient:GetName())
-				currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-				currclient:Message(5,"Pixtt Xxeric Kex says, 'Did you think I would let you enter these halls without consequence?");
+			function(ent, hate, damage, frenzy)
+				if(ent:IsClient() and ent:GetX() < 49 or ent:GetY() < -243 or ent:GetY() > -86 or ent:GetX() > 195) then
+					local currclient=ent:CastToClient();
+					--e.self:Shout("You will not evade me " .. currclient:GetName())
+					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
+					currclient:Message(5,"Pixtt Xxeric Kex says, 'Did you think I would let you enter these halls without consequence?");
+				end
 			end
-		  end
 		);
-  end
+	end
 end
-    
+
 function PXK_Juxtapincer_Death(e)
-  if ( juxtapincer < 3 ) then
-    juxtapincer = juxtapincer + 1;
-    eq.spawn2(298044,0,0, 151, -113, -6.87, 314); -- NPC: an_ukun_juxtapincer
-    e.self:Emote("flesh and bones are reformed by dark magic");
-  end
+	if juxtapincer < 3 then
+		juxtapincer = juxtapincer + 1;
+		eq.spawn2(298044,0,0, 151, -113, -6.87, 314); -- NPC: an_ukun_juxtapincer
+		e.self:Emote("flesh and bones are reformed by dark magic");
+	end
 end
 
 function PXK_Lifebleeder_Death(e)
-  if (lifebleeder < 3) then
-    lifebleeder = lifebleeder + 1;
-    eq.spawn2(298043,0,0, 151, -218, -6.87, 450); -- NPC: an_ukun_lifebleeder
-    e.self:Emote("flesh and bones are reformed by dark magic");
-  end
+	if lifebleeder < 3 then
+		lifebleeder = lifebleeder + 1;
+		eq.spawn2(298043,0,0, 151, -218, -6.87, 450); -- NPC: an_ukun_lifebleeder
+		e.self:Emote("flesh and bones are reformed by dark magic");
+	end
 end
 
 function PXK_Manasipper_Death(e)
-  if (manasipper < 3) then
-    manasipper = manasipper + 1;
-    eq.spawn2(298042,0,0,  81, -113, -6.87,  194); -- NPC: an_ukun_manasipper
-    e.self:Emote("flesh and bones are reformed by dark magic");
-  end
+	if manasipper < 3 then
+		manasipper = manasipper + 1;
+		eq.spawn2(298042,0,0,  81, -113, -6.87,  194); -- NPC: an_ukun_manasipper
+		e.self:Emote("flesh and bones are reformed by dark magic");
+	end
 end
 
 function PXK_Ragehound_Death(e)
-  if (ragehound < 3) then
-    ragehound = ragehound + 1;
-    eq.spawn2(298041,0,0,  81, -218, -6.87,  40); -- NPC: an_ukun_ragehound
-    e.self:Emote("flesh and bones are reformed by dark magic");
-  end
+	if ragehound < 3 then
+		ragehound = ragehound + 1;
+		eq.spawn2(298041,0,0,  81, -218, -6.87,  40); -- NPC: an_ukun_ragehound
+		e.self:Emote("flesh and bones are reformed by dark magic");
+	end
 end
 
 function event_encounter_load(e)
-  inst_id = eq.get_zone_instance_id();
+	eq.register_npc_event('pxk', Event.spawn,  298039, PXK_Spawn);
+	eq.register_npc_event('pxk', Event.combat, 298039, PXK_Combat);
+	eq.register_npc_event('pxk', Event.hp,     298039, PXK_Hp);
+	eq.register_npc_event('pxk', Event.timer,     298039, PXK_Timer);
 
-  eq.register_npc_event('pxk', Event.spawn,  298039, PXK_Spawn);
-  eq.register_npc_event('pxk', Event.combat, 298039, PXK_Combat);
-  eq.register_npc_event('pxk', Event.hp,     298039, PXK_Hp);
-  eq.register_npc_event('pxk', Event.timer,     298039, PXK_Timer);
+	eq.register_npc_event('pxk', Event.death_complete, 298044, PXK_Juxtapincer_Death);
+	eq.register_npc_event('pxk', Event.death_complete, 298043, PXK_Lifebleeder_Death);
+	eq.register_npc_event('pxk', Event.death_complete, 298042, PXK_Manasipper_Death);
+	eq.register_npc_event('pxk', Event.death_complete, 298041, PXK_Ragehound_Death);
 
-  eq.register_npc_event('pxk', Event.death_complete, 298044, PXK_Juxtapincer_Death);
-  eq.register_npc_event('pxk', Event.death_complete, 298043, PXK_Lifebleeder_Death);
-  eq.register_npc_event('pxk', Event.death_complete, 298042, PXK_Manasipper_Death);
-  eq.register_npc_event('pxk', Event.death_complete, 298041, PXK_Ragehound_Death);
-
-  eq.register_npc_event('pxk', Event.death_complete, 298039, PXK_Death);
+	eq.register_npc_event('pxk', Event.death_complete, 298039, PXK_Death);
 end
 
 function event_encounter_unload(e)
-    eq.depop_all(298044);
-    eq.depop_all(298043);
-    eq.depop_all(298042);
-    eq.depop_all(298041);
-    eq.depop_all(298039);
+	eq.depop_all(298044);
+	eq.depop_all(298043);
+	eq.depop_all(298042);
+	eq.depop_all(298041);
+	eq.depop_all(298039);
 end

--- a/tacvi/encounters/tmcv.lua
+++ b/tacvi/encounters/tmcv.lua
@@ -1,148 +1,5 @@
---[[
--- Initial Fight
---
--- Tunat`Muram Cuu Vauax says 'You have defiled my chambers and destroyed my officers. I will crush your soul and suck the marrow from your bones.'
---
--- Tunat`Muram Cuu Vauax hits for a max ~4,400 (no rampage; no flurry; no special effects). He is permanently rooted in place and summons when damaged. He has an extra summon for players who try to get away from him:
---
--- Tunat`Muram Cuu Vauax says 'You can not evade my reach so easily, coward!'
--- Tunat`Muram Cuu Vauax begins to cast a spell. <Immobilizing Spikes>
---
--- Immobilizing Spikes: Single Target, Unresistable (0)
--- 1: Root
--- 2: Decrease Hitpoints by 200 per tick
---
--- He is surrounded by nine aneuks. Their sole purpose is to regenerate the Tunat`Muram throughout the event, prolonging his death:
---
--- Tunat`Muram Cuu Vauax pauses for a moment as a portion of his spirit is transferred into one of the phylacteries.
---
--- You can attack and kill these aneuks; however, their DPS output and health are comparable to that of the mastruq mobs encountered in the zone, and they also cast a DOT on whoever is on their hate list.
---
--- Once Tunat`Muram Cuu Vauax reaches 40%, 2x "an ukun biledrinker" become active. You can either kill them or offtank them (they will despawn when Tunat`Muram does). They can be stunned, but not mezzed.
---
--- When Tunat`Muram Cuu Vauax reaches 0%, he despawns and respawns behind the altar area (NOT auto-aggro). This version will be much meaner:
---
--- In an explosion of energy, Tunat'Muram Cuu Vauax disappears while ancient pebbles pelt against your armor.
---
--- The room is filled with an eerie laugh. 'You have done well to defeat my doppelganger and have shown great strength by making it this far, but I'm afraid I must end your struggle here. Your days have been numbered since you first set foot upon this continent and your time is up. Kneel before me and I will grant you a quick death, but resist and you will suffer in ways that will be spoken about in hushed tones for eons to come.
---
---
--- That Was Too Easy; Now the Main Event
---
--- You can take as much time to rez, med, rebuff, etc. as necessary as there is no apparent timer to engage. (This also acts as a reset point for the event. If you fail this part, you don't have to repeat the initial fight.)
---
--- When ready, engage him again. Here, he hits for a max ~4,800 and buffs himself with "Haste of the Tunat'Muram":
---
--- Haste of the Tunat'Muram: Self 0', Unresistable (0) 4740
--- 1: Increase Attack Speed by 50%
--- 2: Increase Damage Shield by 60
---
--- At 90% health and every 10% health after (down to 20%), he transforms into one of his lieutenants:
---
--- Tunat`Muram Cuu Vauax shimmers and changes before your eyes.
---
--- 90%: Pixtt Xxeric Kex (flurries; immediately spawns four ukun adds - stunnable, but not mezzable)
--- 80%: Pixtt Kretv Krakxt (mitigated AE rampage; spawns 4x "an ikaav hatchling" adds if you take too long)
--- 70%: Pixtt Riel Tavas (unstable construct adds if you take too long)
--- 60%: Zun`Muram Kvxe Pirik (single-target rampage; straight melee)
--- 50%: Zun`Muram Yihst Vor (single-target rampage; straight melee)
--- 40%: Zun`Muram Mordl Delt (single-target rampage; flurries; spawns 2x "Zun`Muram Mordl Delt" adds)
--- 30%: Zun`Muram Shaldn Boc (single-target rampage; straight melee)
---
--- At 20%, he reforms as "Tunat`Muram Cuu Vauax" once again...
---
--- Zun`Muram Shaldn Boc shimmers and changes before your eyes.
---
--- Tunat`Muram Cuu Vuaux says 'You are stronger than I anticipated. While you have exhausted the fleeting spirit of my underlings, you have yet to face my true fury!'
---
--- For now, he hits for a max ~5,300 and remains simple enough. By 15% health, however, things start to pick up...
---
--- Below 15% health, he starts hitting for a max ~6,500 and frequently single-target rampages and flurries. He also increases his attack speed and uses an arsenal of spells that are cast with some frequency:
---
--- Haste of the Tunat'Muram: Self 0', Unresistable (0) 4740
--- 1: Increase Attack Speed by 50%
--- 2: Increase Damage Shield by 60
---
--- Bellow of Tunat'Muram: NPC Hatelist 1000', Chromatic (-200) 5555
--- 1: Silence
--- 2: Decrease Hitpoints by 800
--- 3: Increase Curse Counter by 16
--- 4: Decrease Accuracy by 20%
---
--- Discord's Rebuke: PB AE 100', Chromatic (-250) 4739
--- 1: Decrease Hitpoints by 3000
---
--- Gaze of the Tunat'Muram: Targeted AE 30', Prismatic (-300) 5546
--- 1: Decrease Spell Haste by 50%
--- 2: Decrease HP when cast by 1500
--- 3: Decrease Hitpoints by 1000 per tick
--- 4: Decrease WIS by 50
--- 5: Decrease INT by 50
--- 6: Decrease Mana by 150 per tick
--- 7: Limit: Combat Skills Not Allowed
---
--- Ikaav's Venom: PB AE 300', Magic (-300) 751
--- 1: Decrease Attack Speed by 50%
--- 2: Decrease HP when cast by 4050
--- 3: Increase Poison Counter by 36
---
--- Spirit Cleaver: Single Target, Prismatic (-350) 4729
--- 1: Decrease ATK by 500
--- 2: Decrease Hitpoints by 1225 per tick
--- 3: Decrease Mana by 400 per tick
--- 4: Decrease Endurance by 400 per tick
--- 5: Decrease Stats by 350
--- 6: Increase Poison Counter by 99
--- 7: Increase Poison Counter by 99
--- 8: Increase Poison Counter by 99
---
--- Touch of the Tunat'Muram: Targeted AE 30', Prismatic (-300) 5545
--- 1: Decrease HP when cast by 2000
--- 2: Decrease Hitpoints by 1500 per tick
--- 3: Decrease Mana by 100 per tick
--- 4: Decrease Endurance by 100 per tick
--- 5: Decrease STR by 50
--- 6: Decrease ATK by 300
---
--- Wave of Rage: PB AE 100', Prismatic (-350) 4728
--- 1: Decrease Spell Mana Cost by 0%
--- 2: Decrease HP when cast by 4050
--- 3: Decrease Hitpoints by 500 per tick
--- 4: Decrease INT by 400
--- 5: Decrease WIS by 400
--- 6: Increase Poison Counter by 99
--- 7: Increase Poison Counter by 99
--- 8: Increase Poison Counter by 99
--- 9: Increase Poison Counter by 99
--- 10: Limit: Combat Skills Not Allowed
---
--- Kill him to complete the event.
---
---
--- Event Completion & Loot
---
--- Tunat`Muram Cuu Vuaux has been slain by _____!
---
--- Tunat`Muram Cuu Vuaux's corpse says 'Impossible! You have not been tested in the fires of discord, yet you have devastated the best the legion could muster. How can a world untouched by the crucible of chaos breed warriors of such strength? Mata Muram must be warned! He must prepare for your coming!'
---
--- Loot from this event includes 2 "Cracked Shard of Power" (Breakdown in Communication item) + 1 "Tongue of the Tunat'muram" + 2 augmentations (first list) + 2 other items (second list):
---
--- Mobs Used:
---  298014 Tunat (1st)
---  298055 Tunat (2nd)
---  298209 an ukun biledrinker (spawns at 40% of Tunat (1st)'s health)
---  298113 Living Phylactery (Tunat 1st) Guards
---  298044 An ukun juxta pincer: 60k hp, doubles,flurries, 635-2820 min/max
---  298042 an ukun manasipper:double, 600-2120min/max, 116k hp
---  298043 an ukun lifebleeder: doubles, flurries, 80k hp, 600-2120min/max
---  298041 an ukun ragehound: double, flurries, 114k hp, 650-2990
---  298048 an_ikaav_hatchling
---  298045 an_unstable_construct
---  298050 Zun`Muram_Mordl_Delt
---
---]]
 local Ukun_Inactive = "19,1^20,1^21,1^24,1^25,1"; 
-local Ukun_Active = "7,1^13,1^14,1^15,1^17,1^21,1";
+local Ukun_Active = "7,1^13,1^14,1^17,1^21,1";
 
 local lp_mob = nil;
 local tunat_id = nil;
@@ -150,332 +7,528 @@ local tunat_heal = nil;
 local tunat_hp = nil;
 local lp_list = {};
 
+local zmkp_min = nil;
+local zmkp_max = nil;
+
 function Tunat_Second_Spawn()
-  eq.set_next_hp_event(90);
+	eq.set_next_hp_event(90);
 end
 
 function Tunat_Second_Death(e)
-  eq.signal(298223, 298055); -- NPC: zone_status
+	eq.signal(298223, 298055); -- NPC: zone_status
+	eq.signal(298223,2); -- Unlock Doors
 end
 
 function Tunat_Second_HP(e)
-  if (e.hp_event == 90) then
-    -- 90%: Pixtt Xxeric Kex (flurries; immediately spawns four ukun adds - stunnable, but not mezzable)
-    e.self:Emote("shimmers and changes before your eyes.");
-    e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
-    eq.modify_npc_stat("min_hit", "1270");
-    eq.modify_npc_stat("max_hit", "4500");
+	if e.hp_event == 90 then
+		eq.signal(298223,1); -- Lock Doors
 
-    e.self:SendIllusionPacket({race=393,gender=2,texture=11});
-    e.self:TempName("Pixtt Xxeric Kex");
+		-- 90%: Pixtt Xxeric Kex (flurries; immediately spawns four ukun adds - stunnable, but not mezzable)
 
-    -- Spawn Adds
-    eq.spawn2(298044, 0, 0, 334, -117, 21, 280); -- NPC: an_ukun_juxtapincer
-    eq.spawn2(298043, 0, 0, 356, -154, 21, 356); -- NPC: an_ukun_lifebleeder
-    eq.spawn2(298042, 0, 0, 353, -201, 21, 434); -- NPC: an_ukun_manasipper
-    eq.spawn2(298041, 0, 0, 322, -215, 21, 496); -- NPC: an_ukun_ragehound
+		-- Stop Previous Spell Timers
+		eq.stop_timer("Spell_Tunat_Haste");
 
-    -- Rehaste 4740
-    e.self:CastSpell(4740, e.self:GetID()); -- Spell: Haste of the Tunat`Muram
+		-- Transition and set mob variables
+		e.self:Emote("shimmers and changes before your eyes.");
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
+		eq.modify_npc_stat("min_hit", "1262");
+		eq.modify_npc_stat("max_hit", "4500");
+		e.self:SendIllusionPacket({race=393,gender=2,texture=11});
+		e.self:TempName("Pixtt Xxeric Kex");
 
-    eq.set_next_hp_event(80);
+		-- Spawn Adds
+		eq.spawn2(298044, 0, 0, 334, -117, 21, 280); -- NPC: an_ukun_juxtapincer
+		eq.spawn2(298043, 0, 0, 356, -154, 21, 356); -- NPC: an_ukun_lifebleeder
+		eq.spawn2(298042, 0, 0, 353, -201, 21, 434); -- NPC: an_ukun_manasipper
+		eq.spawn2(298041, 0, 0, 322, -215, 21, 496); -- NPC: an_ukun_ragehound
 
-  elseif (e.hp_event == 80) then
-    -- 80%: Pixtt Kretv Krakxt (mitigated AE rampage; spawns 4x "an ikaav hatchling" adds if you take too long)
-    e.self:Emote("shimmers and changes before your eyes.");
-    e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
-    e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
-    eq.modify_npc_stat("min_hit", "1272");
-    eq.modify_npc_stat("max_hit", "4432");
+		-- Phase Spells
+		eq.set_timer("Spell_PXK_SC", 2 * 1000); -- 2s Start Timer
+		eq.set_timer("Spell_PXK_WOR", 60 * 1000); -- 60s Timer
 
-    e.self:SendIllusionPacket({race=394,gender=2,texture=11});
-    e.self:TempName("Pixtt Kretv Kakxt");
+		-- Set next phase
+		eq.set_next_hp_event(80);
 
-    eq.set_timer("pkk_adds", 30 * 1000);
+	elseif e.hp_event == 80 then
+		-- 80%: Pixtt Kretv Krakxt (mitigated AE rampage; spawns 4x "an ikaav hatchling" adds if you take too long)
 
-    -- Rehaste 4740
-    e.self:CastSpell(4740, e.self:GetID()); -- Spell: Haste of the Tunat`Muram
-    
-    eq.set_next_hp_event(70);
+		-- Stop Previous Spell Timers
+		eq.stop_timer("Spell_PXK_SC");
+		eq.stop_timer("Spell_PXK_WOR");
 
-  elseif (e.hp_event == 70) then
-    -- 70%: Pixtt Riel Tavas (unstable construct adds if you take too long)
-    e.self:Emote("shimmers and changes before your eyes.");
-    e.self:SetSpecialAbility(SpecialAbility.area_rampage, 0);
-    eq.modify_npc_stat("min_hit", "1560");
-    eq.modify_npc_stat("max_hit", "4600");
+		-- Transition and set mob variables
+		e.self:Emote("shimmers and changes before your eyes.");
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
+		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 25); -- 75% mitigated aoe ramp dmg
+		eq.modify_npc_stat("min_hit", "1262");
+		eq.modify_npc_stat("max_hit", "4432");
+		e.self:SendIllusionPacket({race=394,gender=2,texture=11});
+		e.self:TempName("Pixtt Kretv Kakxt");
 
-    e.self:SendIllusionPacket({race=394,gender=2,texture=11});
-    e.self:TempName("Pixtt Riel Tavas");
+		-- Add timer
+		eq.set_timer("pkk_adds", 30 * 1000);
 
-    eq.stop_timer("pkk_adds");
-    eq.set_timer("prt_adds", 30 * 1000);
+		-- Phase Spells
+		eq.set_timer("Spell_PKK_DV", 2 * 1000);	-- 2s Start Timer
+		eq.set_timer("Spell_PKK_SC", 5 * 1000);	-- 5s Start Timer
+		eq.set_timer("Spell_PKK_WOTI", 10 * 1000);	-- 10s Start Timer
 
-    -- Rehaste 4740
-    e.self:CastSpell(4740, e.self:GetID()); -- Spell: Haste of the Tunat`Muram
-    
-    eq.set_next_hp_event(60);
+		-- Set next phase
+		eq.set_next_hp_event(70);
 
-  elseif (e.hp_event == 60) then
-    -- 60%: Zun`Muram Kvxe Pirik (single-target rampage; straight melee)
-    e.self:Emote("shimmers and changes before your eyes.");
-    e.self:SendIllusionPacket({race=400,gender=2,texture=11});
-    e.self:TempName("Zun`Muram Kvxe Pirik");
-    eq.modify_npc_stat("min_hit", "1430");
-    eq.modify_npc_stat("max_hit", "3900");
+	elseif e.hp_event == 70 then
+		-- 70%: Pixtt Riel Tavas (unstable construct adds if you take too long)
 
-    eq.stop_timer("prt_adds");
+		-- Stop Previous Spell Timers
+		eq.stop_timer("Spell_PKK_DV");
+		eq.stop_timer("Spell_PKK_SC");
+		eq.stop_timer("Spell_PKK_WOTI");
 
-    eq.set_next_hp_event(50);
+		-- Transition and set mob variables
+		e.self:Emote("shimmers and changes before your eyes.");
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 0);
+		eq.modify_npc_stat("min_hit", "1552");
+		eq.modify_npc_stat("max_hit", "4600");
+		e.self:SendIllusionPacket({race=394,gender=2,texture=11});
+		e.self:TempName("Pixtt Riel Tavas");
 
-  elseif (e.hp_event == 50) then
-    -- 50%: Zun`Muram Yihst Vor (single-target rampage; straight melee)
-    e.self:Emote("shimmers and changes before your eyes.");
-    e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
-    e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
-    eq.modify_npc_stat("min_hit", "1650");
-    eq.modify_npc_stat("max_hit", "4500");
+		-- Add timer
+		eq.stop_timer("pkk_adds");
+		eq.set_timer("prt_adds", 30 * 1000);
 
-    e.self:SendIllusionPacket({race=400,gender=2,texture=11});
-    e.self:TempName("Zun`Muram Yihst Vor");
+		-- Phase Spells
+		eq.set_timer("Spell_PRT_DV", 2 * 1000);	-- 2s Start Timer
+		eq.set_timer("Spell_PRT_WOTI", math.random(10,20) * 1000);	-- 10s-20 Start Timer
 
-    -- Rehaste 4740
-    e.self:CastSpell(4740, e.self:GetID()); -- Spell: Haste of the Tunat`Muram
-    
-    eq.set_next_hp_event(40);
+		-- Set next phase
+		eq.set_next_hp_event(60);
 
-  elseif (e.hp_event == 40) then
-    -- 40%: Zun`Muram Mordl Delt (single-target rampage; flurries; spawns 2x "Zun`Muram Mordl Delt" adds)
-    e.self:Emote("shimmers and changes before your eyes.");
-    e.self:SetSpecialAbility(SpecialAbility.area_rampage, 0);
-    e.self:SetSpecialAbility(SpecialAbility.rampage, 1);
-    e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
-    eq.modify_npc_stat("min_hit", "1350");
-    eq.modify_npc_stat("max_hit", "4200");
+	elseif e.hp_event == 60 then
+		-- 60%: Zun`Muram Kvxe Pirik (single-target rampage; Powers Up 30s; straight melee)
 
-    e.self:SendIllusionPacket({race=400,gender=2,texture=11});
-    e.self:TempName("Zun`Muram Mordl Delt");
+		-- Stop Previous Spell Timers
+		eq.stop_timer("Spell_PRT_DV");
+		eq.stop_timer("Spell_PRT_WOTI");
 
-    eq.spawn2(298050, 0, 0, 334, -117, 21, 280); -- NPC: Zun`Muram_Mordl_Delt
-    eq.spawn2(298050, 0, 0, 356, -154, 21, 356); -- NPC: Zun`Muram_Mordl_Delt
-    
-    -- Rehaste 4740
-    e.self:CastSpell(4740, e.self:GetID()); -- Spell: Haste of the Tunat`Muram
-    
-    eq.set_next_hp_event(30);
+		-- Transition and set mob variables
+		e.self:Emote("shimmers and changes before your eyes.");
+		e.self:SendIllusionPacket({race=400,gender=2,texture=11});
+		e.self:TempName("Zun`Muram Kvxe Pirik");
+		e.self:ModifyNPCStat("attack_delay","9");
+		eq.modify_npc_stat("min_hit", "1424");
+		zmkp_min = 1424;
+		eq.modify_npc_stat("max_hit", "3900");
+		zmkp_max = 3900;
 
-  elseif (e.hp_event == 30) then
-    -- 30%: Zun`Muram Shaldn Boc (single-target rampage; straight melee)
-    e.self:Emote("shimmers and changes before your eyes.");
-    e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
-    eq.modify_npc_stat("min_hit", "1470");
-    eq.modify_npc_stat("max_hit", "4700");
+		-- Add timer
+		eq.stop_timer("prt_adds");
 
-    e.self:SendIllusionPacket({race=400,gender=2,texture=11});
-    e.self:TempName("Zun`Muram Shaldn Boc");
+		-- Power Up timer
+		eq.set_timer("zmkp_powerup_first", 35 * 1000);
 
-    -- Rehaste 4740
-    e.self:CastSpell(4740, e.self:GetID()); -- Spell: Haste of the Tunat`Muram
-    
-    eq.set_next_hp_event(20);
+		-- Set next phase
+		eq.set_next_hp_event(50);
 
-  elseif (e.hp_event == 20) then
-    -- 20%: he reforms as Tunat`Muram Cuu Vauax once again...
-    e.self:Emote("shimmers and changes before your eyes.");
-    e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
-    eq.modify_npc_stat("min_hit", "1450");
-    eq.modify_npc_stat("max_hit", "4300");
+	elseif e.hp_event == 50 then
+		-- 50%: Zun`Muram Yihst Vor (mitigated AE rampage; Flurry; straight melee)
 
-    e.self:SendIllusionPacket({race=399,gender=2,texture=11});
-    e.self:TempName("Tunat`Muram Cuu Vauax");
+		-- End power up cycle
+		eq.stop_timer("zmkp_powerup_repeat");
 
-    -- Rehaste 4740
-    e.self:CastSpell(4740, e.self:GetID()); -- Spell: Haste of the Tunat`Muram
-    
-    eq.set_timer("ae_timer", 3 * 1000);
+		-- Transition and set mob variables
+		e.self:Emote("shimmers and changes before your eyes.");
+		e.self:ModifyNPCStat("attack_delay","15");
+		eq.modify_npc_stat("min_hit", "1643");
+		eq.modify_npc_stat("max_hit", "4500");
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 0);
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
+		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 25); -- 75% mitigated aoe ramp dmg		
+		e.self:SendIllusionPacket({race=400,gender=2,texture=11});
+		e.self:TempName("Zun`Muram Yihst Vor");
+		
+		-- Phase Spells
+		eq.set_timer("Spell_ZMYV_AOH", 60 * 1000); -- 60s Timer
 
-  end
+		-- Set next phase
+		eq.set_next_hp_event(40);
+
+	elseif e.hp_event == 40 then
+		-- 40%: Zun`Muram Mordl Delt (single-target rampage; flurries; spawns 2x "Zun`Muram Mordl Delt" adds)
+
+		-- Stop Previous Spell Timers
+		eq.stop_timer("Spell_ZMYV_AOH");
+
+		-- Transition and set mob variables
+		e.self:Emote("shimmers and changes before your eyes.");
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 0);
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 1);
+		e.self:SetSpecialAbilityParam(SpecialAbility.rampage, 2, 25); -- 75% mitigated ramp dmg
+		eq.modify_npc_stat("min_hit", "1343");
+		eq.modify_npc_stat("max_hit", "4200");
+		e.self:SendIllusionPacket({race=400,gender=2,texture=11});
+		e.self:TempName("Zun`Muram Mordl Delt");
+
+		-- Spawn Adds
+		eq.set_timer("ZMMD_Adds",20 * 1000); -- Spawn Adds 20s after phase start
+		
+		-- Set next phase
+		eq.set_next_hp_event(30);
+
+	elseif e.hp_event == 30 then
+		-- 30%: Zun`Muram Shaldn Boc (single-target rampage; Rages; straight melee)
+
+		-- Transition and set mob variables
+		e.self:Emote("shimmers and changes before your eyes.");
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
+		eq.modify_npc_stat("min_hit", "1462");
+		eq.modify_npc_stat("max_hit", "4700");
+		e.self:SendIllusionPacket({race=400,gender=2,texture=11});
+		e.self:TempName("Zun`Muram Shaldn Boc");
+
+		-- Rage Timer
+		eq.set_timer("zmsb_rage", 30 * 1000);
+		
+		-- Set next phase
+		eq.set_next_hp_event(20);
+
+	elseif e.hp_event == 20 then
+		-- 20%: he reforms as Tunat`Muram Cuu Vauax once again...
+
+		-- Stop previous rage
+		eq.stop_timer("zmsb_rage");
+		eq.stop_timer("zmsb_rage_over");
+
+		-- Transition and set mob variables
+		e.self:Emote("shimmers and changes before your eyes.");
+		e.self:Say("You are stronger than I anticipated. While you have exhausted the fleeting spirit of my underlings, you have yet to face my true fury!");
+		eq.modify_npc_stat("min_hit", "1450");
+		eq.modify_npc_stat("max_hit", "4300");
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 1);
+		e.self:SetSpecialAbilityParam(SpecialAbility.rampage, 2, 25); -- 75% mitigated ramp dmg
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
+		e.self:SendIllusionPacket({race=399,gender=2,texture=11});
+		e.self:TempName("Tunat`Muram Cuu Vauax");
+
+		-- Rage Timer
+		eq.set_timer("tunat_rage", 30 * 1000);
+		eq.set_timer("Spell_Tunat_Haste",2 * 1000); -- 2s Start Timer
+
+		-- Phase Spells
+		e.self:CastSpell(4740, e.self:GetID());	-- Spell: Haste of the Tunat`Muram
+		eq.set_timer("Spells_Tunat_Final1", 20 * 1000); -- 20s Start Timer
+		eq.set_timer("Spells_Tunat_Final2", 35 * 1000); -- 35s Start Timer
+
+		eq.set_next_hp_event(15);
+	end
 end
 
 function Tunat_First_Death(e)
+	eq.zone_emote(0, "Tunat`Muram Cuu Vauax says, 'In an explosion of energy, Tunat'Muram Cuu Vauax disappears while ancient pebbles pelt against your armor.'");
+	eq.zone_emote(15,"The room is filled with an eerie laugh. 'You have done well to defeat my doppelganger and have shown great strength by making it this far, but I'm afraid I must end your struggle here. Your days have been numbered since you first set foot upon this continent and your time is up. Kneel before me and I will grant you a quick death, but resist and you will suffer in ways that will be spoken about in hushed tones for eons to come.");
 	eq.spawn2(298055,0,0, 309, -170.8, 21.3, 118.8); -- NPC: #Tunat`Muram_Cuu_Vauax
-
-  eq.depop_all(298113);
-  eq.depop_all(298209);
+	eq.depop_all(298113);
+	eq.depop_all(298209);
 end
 
 function Tunat_First_Spawn(e)
-  eq.set_next_hp_event(40);
+	eq.signal(298223,2); -- Unlock Doors
+	eq.set_next_hp_event(90);
 
-  -- Spawn the Dogs
-  eq.spawn2(298209, 0, 0, 445, -203, 25, 34); -- NPC: an_ukun_biledrinker
-  eq.spawn2(298209, 0, 0, 447, -139, 25, 198); -- NPC: an_ukun_biledrinker
+	-- Spawn the Dogs
+	eq.spawn2(298209, 0, 0, 445, -203, 25, 34); -- NPC: an_ukun_biledrinker
+	eq.spawn2(298209, 0, 0, 447, -139, 25, 198); -- NPC: an_ukun_biledrinker
 
-  -- Spawn the Living
-  lp_list[1] = eq.spawn2(298113, 0, 0,500.00, -152.00, 23.75, 112); -- NPC: Living_Phylactery
-  lp_list[2] = eq.spawn2(298113, 0, 0,507.00, -172.00, 23.75, 112); -- NPC: Living_Phylactery
-  lp_list[3] = eq.spawn2(298113, 0, 0,498.00, -193.00, 23.75, 112); -- NPC: Living_Phylactery
-  lp_list[4] = eq.spawn2(298113, 0, 0,476.00, -242.00, 23.75, 246); -- NPC: Living_Phylactery
-  lp_list[5] = eq.spawn2(298113, 0, 0,428.00, -242.00, 23.75, 246); -- NPC: Living_Phylactery
-  lp_list[6] = eq.spawn2(298113, 0, 0,454.00, -242.00, 23.75, 246); -- NPC: Living_Phylactery
-  lp_list[7] = eq.spawn2(298113, 0, 0,478.00, -100.00, 23.75, 28); -- NPC: Living_Phylactery
-  lp_list[8] = eq.spawn2(298113, 0, 0,454.00, -100.00, 23.75, 28); -- NPC: Living_Phylactery
-  lp_list[9] = eq.spawn2(298113, 0, 0,431.00, -100.00, 23.75, 28); -- NPC: Living_Phylactery
+	-- Spawn the Living
+	lp_list[1] = eq.spawn2(298113, 0, 0,500.00, -152.00, 23.75, 112); -- NPC: Living_Phylactery
+	lp_list[2] = eq.spawn2(298113, 0, 0,507.00, -172.00, 23.75, 112); -- NPC: Living_Phylactery
+	lp_list[3] = eq.spawn2(298113, 0, 0,498.00, -193.00, 23.75, 112); -- NPC: Living_Phylactery
+	lp_list[4] = eq.spawn2(298113, 0, 0,476.00, -242.00, 23.75, 246); -- NPC: Living_Phylactery
+	lp_list[5] = eq.spawn2(298113, 0, 0,428.00, -242.00, 23.75, 246); -- NPC: Living_Phylactery
+	lp_list[6] = eq.spawn2(298113, 0, 0,454.00, -242.00, 23.75, 246); -- NPC: Living_Phylactery
+	lp_list[7] = eq.spawn2(298113, 0, 0,478.00, -100.00, 23.75, 28); -- NPC: Living_Phylactery
+	lp_list[8] = eq.spawn2(298113, 0, 0,454.00, -100.00, 23.75, 28); -- NPC: Living_Phylactery
+	lp_list[9] = eq.spawn2(298113, 0, 0,431.00, -100.00, 23.75, 28); -- NPC: Living_Phylactery
 
 end
 
 function Tunat_First_HP(e)
-  if (e.hp_event == 40) then
-    -- Wake up the dogs.
-    eq.signal(298209, 1); -- NPC: an_ukun_biledrinker
-  end
+	if (e.hp_event == 90) then
+		eq.signal(298223,1); -- Lock Doors
+		eq.set_next_hp_event(40);
+	elseif (e.hp_event == 40) then
+		-- Wake up the dogs.
+		eq.signal(298209, 1); -- NPC: an_ukun_biledrinker
+	end
 end
 
 function Tunat_Second_Timer(e)
+	if e.timer == "pkk_adds" then
+		eq.spawn2(298013, 0, 0, 334, -117, 21, 280); -- NPC: an_ikaav_hatchling --change these so they dont trigger PKK Script.
+		eq.spawn2(298013, 0, 0, 356, -154, 21, 356); -- NPC: an_ikaav_hatchling
+		eq.spawn2(298013, 0, 0, 353, -201, 21, 434); -- NPC: an_ikaav_hatchling
+		eq.spawn2(298013, 0, 0, 322, -215, 21, 496); -- NPC: an_ikaav_hatchling
 
-  if (e.timer == "pkk_adds") then
-    eq.spawn2(298013, 0, 0, 334, -117, 21, 280); -- NPC: an_ikaav_hatchling --change these so they dont trigger PKK Script.
-    eq.spawn2(298013, 0, 0, 356, -154, 21, 356); -- NPC: an_ikaav_hatchling
-    eq.spawn2(298013, 0, 0, 353, -201, 21, 434); -- NPC: an_ikaav_hatchling
-    eq.spawn2(298013, 0, 0, 322, -215, 21, 496); -- NPC: an_ikaav_hatchling
+	elseif e.timer == "prt_adds" then
+		eq.spawn2(298045, 0, 0, 334, -117, 21, 280); -- NPC: an_unstable_construct
+		eq.spawn2(298045, 0, 0, 356, -154, 21, 356); -- NPC: an_unstable_construct
+		eq.spawn2(298045, 0, 0, 353, -201, 21, 434); -- NPC: an_unstable_construct
+		eq.spawn2(298045, 0, 0, 322, -215, 21, 496); -- NPC: an_unstable_construct
+		eq.spawn2(298045, 0, 0, 322, -225, 21, 496); -- NPC: an_unstable_construct
+	elseif e.timer == "zmkp_powerup_first" then
+		eq.stop_timer("zmkp_powerup_first");
 
-  elseif (e.timer == "prt_adds") then
-    eq.spawn2(298045, 0, 0, 334, -117, 21, 280); -- NPC: an_unstable_construct
-    eq.spawn2(298045, 0, 0, 356, -154, 21, 356); -- NPC: an_unstable_construct
-    eq.spawn2(298045, 0, 0, 353, -201, 21, 434); -- NPC: an_unstable_construct
-    eq.spawn2(298045, 0, 0, 322, -215, 21, 496); -- NPC: an_unstable_construct
-    eq.spawn2(298045, 0, 0, 322, -225, 21, 496); -- NPC: an_unstable_construct
+		-- Set Ramp - Observed 25%
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 1);
+		e.self:SetSpecialAbilityParam(SpecialAbility.rampage, 2, 25); -- 75% mitigated ramp dmg
 
-  elseif (e.timer == "ae_timer") then
-    local cast_ae = eq.ChooseRandom(1,2,3);
+		e.self:ModifyNPCStat("attack_delay","28");
 
-    if (cast_ae == 1) then
-      -- 5546 -- Gaze of the Tunat'Muram
-      -- 4729 -- Spirit Cleaver
-      -- 4728 -- Wave of Rage
-      -- 4727 -- Spear of Discord
-      -- 751  -- Ikaav's Venom
-      ae_spell = eq.ChooseRandom(5546, 4729, 4728, 4727, 751);
-      e.self:CastSpell(ae_spell, e.self:GetTarget():GetID(), 1, 1);
-    end
-    
-  elseif (e.timer == "wipe_check2") then
-    eq.stop_all_timers();
+		-- Scale up each cycle - +700  max hit / +188 min hit
+		zmkp_min = zmkp_min + 188;
+		eq.modify_npc_stat("min_hit", tostring(zmkp_min));
+		zmkp_max = zmkp_max + 700;
+		eq.modify_npc_stat("max_hit", tostring(zmkp_max));
+		-- Start cycle
+		eq.set_timer("zmkp_powerup_repeat", 35 * 1000);		
+	elseif e.timer == "zmkp_powerup_repeat" then
+		-- Scale up each cycle - +700  max hit / +188 min hit
+		eq.zone_emote(15,"Zun`Muram Kvxe Pirik focuses his will and grows stronger.");
+		zmkp_min = zmkp_min + 188;
+		eq.modify_npc_stat("min_hit", tostring(zmkp_min));
+		zmkp_max = zmkp_max + 700;
+		eq.modify_npc_stat("max_hit", tostring(zmkp_max));
+	elseif e.timer == "ZMMD_Adds" then
+		eq.stop_timer("ZMMD_Adds");
+		eq.spawn2(298050, 0, 0, 334, -117, 21, 280); -- NPC: Zun`Muram_Mordl_Delt
+		eq.spawn2(298050, 0, 0, 356, -154, 21, 356); -- NPC: Zun`Muram_Mordl_Delt
+	elseif e.timer == "zmsb_rage" then
+		eq.zone_emote(15,"Zun`Muram Shaldn Boc starts to foam at the mouth as he enters a blind rage.");
+		eq.stop_timer("zmsb_rage");
+		e.self:ModifyNPCStat("attack_delay","9");
+		eq.modify_npc_stat("min_hit", "2010");
+		eq.modify_npc_stat("max_hit", "6200");
+		eq.set_timer("zmsb_rage_over", 25 * 1000);
+	elseif e.timer == "zmsb_rage_over" then
+		eq.zone_emote(15,"Zun`Muram Shaldn Boc looks weakened as the rage ends.");
+		eq.stop_timer("zmsb_rage_over");
+		e.self:ModifyNPCStat("attack_delay","15");
+		eq.modify_npc_stat("min_hit", "1462");
+		eq.modify_npc_stat("max_hit", "4700");
+		eq.set_timer("zmsb_rage", 30 * 1000);
+	elseif e.timer == "tunat_rage" then
+		eq.zone_emote(15,"Tunat`Muram Cuu Vuaux starts to foam at the mouth as he enters a blind rage.");
+		eq.stop_timer("tunat_rage");
+		e.self:ModifyNPCStat("attack_delay","9");
+		eq.modify_npc_stat("min_hit", "1990");
+		eq.modify_npc_stat("max_hit", "5800");
+		eq.set_timer("tunat_rage_over", 25 * 1000);
+	elseif e.timer == "tunat_rage_over" then
+		eq.zone_emote(15,"Tunat`Muram Cuu Vuaux looks weakened as the rage ends.");
+		eq.stop_timer("tunat_rage_over");
+		e.self:ModifyNPCStat("attack_delay","15");
+		eq.modify_npc_stat("min_hit", "1450");
+		eq.modify_npc_stat("max_hit", "4300");
+		eq.set_timer("tunat_rage", 30 * 1000);
+	elseif e.timer == "wipe_check2" then
+		eq.stop_all_timers();
+		eq.signal(298223,2); -- Unlock Doors
+		eq.depop_all(298044);
+		eq.depop_all(298043);
+		eq.depop_all(298042);
+		eq.depop_all(298041);
+		eq.depop_all(298048);
+		eq.depop_all(298045);
+		eq.depop_all(298209);
+		eq.depop_all(298050);
+		eq.depop_all(298013);
+		eq.spawn2(298055,0,0, 309, -170.8, 21.3, 118.8); -- NPC: #Tunat`Muram_Cuu_Vauax
+		eq.depop();
 
-    eq.depop_all(298044);
-    eq.depop_all(298043);
-    eq.depop_all(298042);
-    eq.depop_all(298041);
+	--
+	-- Spells
+	--
 
-    eq.depop_all(298048);
-    eq.depop_all(298045);
+	-- Tunat 100%
+	elseif e.timer == "Spell_Tunat_Haste" then
+		eq.stop_timer("Spell_Tunat_Haste");
+		if (e.self:GetHPRatio() > 90 or e.self:GetHPRatio() < 20) then
+			e.self:CastSpell(4740, e.self:GetID()); -- Spell: Haste of the Tunat`Muram
+		end
+		eq.set_timer("Spell_Tunat_Haste",30 * 1000); -- 30s Timer
 
-    eq.depop_all(298209);
+	-- PXK 90%	
+	elseif e.timer == "Spell_PXK_SC" then
+		eq.stop_timer("Spell_PXK_SC");
+		e.self:CastedSpellFinished(4729, e.self:GetHateTop());	-- Spell: Spirit Cleaver: Single Target, Prismatic (-350)
+		eq.set_timer("Spell_PXK_SC",math.random(45,60) * 1000); -- Random 45-60s Timer
 
-    eq.depop_all(298050);
+	elseif e.timer == "Spell_PXK_WOR" then
+		e.self:CastedSpellFinished(4728, e.self:GetHateTop());	-- Spell: Wave of Rage: PB AE 100', Prismatic (-350)
 
-    eq.spawn2(298055,0,0, 309, -170.8, 21.3, 118.8); -- NPC: #Tunat`Muram_Cuu_Vauax
-    eq.depop();
+	-- PKK 80%	
+	elseif e.timer == "Spell_PKK_DV" then
+		eq.stop_timer("Spell_PKK_DV");
+		e.self:CastedSpellFinished(889, e.self:GetHateTop());	-- Spell: Delusional Visions: Single Target, Chromatic (-350)
+		eq.set_timer("Spell_PKK_DV",30 * 1000); -- 30s Timer
 
-  end
+	elseif e.timer == "Spell_PKK_SC" then
+		eq.stop_timer("Spell_PKK_SC");
+		e.self:CastedSpellFinished(852, e.self:GetHateTop());	-- Spell: Soul Consumption: Single Target, Prismatic (-350)
+		eq.set_timer("Spell_PKK_SC",math.random(35,45) * 1000); -- Random 35-45s Timer
+
+	elseif e.timer == "Spell_PKK_WOTI" then
+		eq.stop_timer("Spell_PKK_WOTI");
+		e.self:CastedSpellFinished(888, e.self:GetHateTop());	-- Spell: Wrath of the Ikaav: Single Target, Unresistable
+		eq.set_timer("Spell_PKK_WOTI",math.random(30,60) * 1000); -- Random 30-60s Timer
+
+	-- PRT 70%	
+	elseif e.timer == "Spell_PRT_DV" then
+		eq.stop_timer("Spell_PRT_DV");
+		e.self:CastedSpellFinished(889, e.self:GetHateTop());	-- Spell: Delusional Visions: Single Target, Chromatic (-350)
+		eq.set_timer("Spell_PRT_DV",math.random(30,60) * 1000); -- Random 30-60s Timer
+
+	elseif e.timer == "Spell_PRT_WOTI" then
+		eq.stop_timer("Spell_PRT_WOTI");
+		e.self:CastedSpellFinished(888, e.self:GetHateTop());	-- Spell: Wrath of the Ikaav: Single Target, Unresistable
+		eq.set_timer("Spell_PRT_WOTI",math.random(60,180) * 1000); -- Random 60-180s Timer
+
+	-- PRT 50%
+	elseif e.timer == "Spell_ZMYV_AOH" then
+		eq.stop_timer("Spell_ZMYV_AOH");
+		
+		for i=1,2 do -- Two Casts
+			local target = e.self:GetHateRandom();
+			if target:IsPet() then
+				target = target:GetOwner();
+			end
+
+			if target.valid and not target:FindBuff(4441) then
+				e.self:SpellFinished(4441, target); -- Spell: Allure of Hatred
+			end
+		end
+
+		e.self:WipeHateList();
+		eq.set_timer("Spell_ZMYV_AOH",60 * 1000); -- 60s Timer
+
+	-- Tunat 20%
+	elseif e.timer == "Spells_Tunat_Final1" then
+		--spear of discord [20s interval ]
+		--spirit cleaver [20s interval ]
+		--soul consumption [20s interval ]
+		e.self:CastedSpellFinished(eq.ChooseRandom(4727, 4729, 852), e.self:GetHateRandom());
+		
+	elseif e.timer == "Spells_Tunat_Final2" then
+		--ikaavs venom [35s interval ]
+		--wave of rage [35s interval ]
+		--discords rebuke [35s interval ]
+		e.self:CastedSpellFinished(eq.ChooseRandom(751, 4739, 4728), e.self:GetHateRandom());
+	end
 end
 
 function Tunat_Second_Combat(e)
-  if (e.joined == true) then
-    eq.stop_timer('wipe_check2');
-  else
-    eq.set_timer('wipe_check2', 300 * 1000);
-  end
-
+	if e.joined then
+		eq.stop_timer("wipe_check2");
+		eq.set_timer("Spell_Tunat_Haste", 2 * 1000); -- 2s Start Timer
+	else
+		eq.set_timer("wipe_check2", 300 * 1000);
+	end
 end
 
 function Tunat_First_Combat(e)
-  if (e.joined == true) then
-    e.self:Say("You have defiled my chambers and destroyed my officers. I will crush your soul and suck the marrow from your bones.");
-    eq.set_timer('lp_store', eq.ChooseRandom(40, 49, 50, 65, 111) * 1000);
-    eq.stop_timer('wipe_check1');
-  else
-    eq.set_timer('wipe_check1', 300 * 1000);
-  end
+	if e.joined then
+		e.self:Say("You have defiled my chambers and destroyed my officers. I will crush your soul and suck the marrow from your bones.");
+		eq.set_timer("lp_store", eq.ChooseRandom(40, 49, 50, 65, 111) * 1000);
+		eq.stop_timer("wipe_check1");
+	else
+		eq.set_timer("wipe_check1", 300 * 1000);
+	end
 end
 
 function Tunat_First_Timer(e)
-  if (e.timer == 'lp_store') then
-    eq.stop_timer(e.timer);
-    e.self:Emote("pauses for a moment as a portion of his spirit is transferred into one of the phylacteries. ");
+	if e.timer == "lp_store" then
+		eq.stop_timer("lp_store");
+		e.self:Emote("pauses for a moment as a portion of his spirit is transferred into one of the phylacteries. ");
 
-    lp_mob = lp_list[ eq.ChooseRandom(1,2,3,4,5,6,7,8,9)]; 
-    tunat_heal = e.self:GetMaxHP() * 0.10;
+		lp_mob = lp_list[ eq.ChooseRandom(1,2,3,4,5,6,7,8,9)]; 
+		tunat_heal = e.self:GetMaxHP() * 0.10;
 
-    e.self:FaceTarget(lp_mob);
-    e.self:CastSpell(4448, lp_mob:GetID(), 1, 2); -- Spell: ShieldSP
+		e.self:FaceTarget(lp_mob);
+		e.self:CastSpell(4448, lp_mob:GetID(), 1, 2); -- Spell: ShieldSP
 
-    eq.set_timer('lp_heal', 30 * 1000 );
-  elseif (e.timer == 'lp_heal') then
-    eq.stop_timer(e.timer);
-    eq.set_timer('lp_store', eq.ChooseRandom(40, 49, 50, 65, 111) * 1000);
-    
-    tunat_id = e.self:GetID();
-    tunat_hp = e.self:GetHP();
+		eq.set_timer("lp_heal", 30 * 1000 );
+	elseif e.timer == "lp_heal" then
+		eq.stop_timer("lp_heal");
+		eq.set_timer("lp_store", eq.ChooseRandom(40, 49, 50, 65, 111) * 1000);
+		
+		tunat_id = e.self:GetID();
+		tunat_hp = e.self:GetHP();
 
-    lp_mob:FaceTarget(e.self);
-    lp_mob:CastSpell(4448, e.self:GetID(), 1, 3 ); -- Spell: ShieldSP
-    e.self:SetHP( tunat_hp + tunat_heal );
-    e.self:Emote("staggers as the portion of his spirit that was stored in the phylactery flows back into him.");
+		lp_mob:FaceTarget(e.self);
+		lp_mob:CastSpell(4448, e.self:GetID(), 1, 3 ); -- Spell: ShieldSP
+		e.self:SetHP( tunat_hp + tunat_heal );
+		e.self:Emote("staggers as the portion of his spirit that was stored in the phylactery flows back into him.");
 
-  elseif (e.timer == "wipe_check1") then
-    -- Reset to the 1st Tunat 
-    eq.depop();
-    eq.depop_all(298113);
-    eq.depop_all(298209);
-    eq.spawn2(298014, 0, 0, 462, -171, 32, 16); -- NPC: #Tunat`Muram_Cuu_Vauax
+	elseif e.timer == "wipe_check1" then
+		-- Reset to the 1st Tunat 
+		eq.signal(298223,2); -- Unlock Doors
+		eq.depop();
+		eq.depop_all(298113);
+		eq.depop_all(298209);
+		eq.spawn2(298014, 0, 0, 462, -171, 32, 16); -- NPC: #Tunat`Muram_Cuu_Vauax
 
-  end
+	end
 end
 
 function LP_Combat(e)
-  if (e.joined == true) then
-    eq.set_timer('lp_ae', 30 * 1000);
-  end
+	if e.joined then
+		eq.set_timer("lp_ae", 30 * 1000);
+	end
 end
 
 function LP_Death(e)
-  e.self:CastSpell(6495, e.self:GetID()); -- Spell: Spiritual Wake
+	e.self:SpellFinished(6495, e.self:GetID()); -- Spell: Spiritual Wake
 end
 
 function LP_Timer(e)
-  if (e.timer == 'lp_ae') then
-    e.self:CastSpell(5546, e.self:GetTarget():GetID()); -- Spell: Gaze of the Tunat`Muram
-  end
+	if e.timer == "lp_ae" then
+		e.self:CastSpell(5546, e.self:GetTarget():GetID()); -- Spell: Gaze of the Tunat`Muram
+	end
 end
 
 function Ukun_Spawn(e)
-  -- When the Dogs spawn set the inactive
-  e.self:ProcessSpecialAbilities(Ukun_Inactive);
+	-- When the Dogs spawn set the inactive
+	e.self:ProcessSpecialAbilities(Ukun_Inactive);
+	eq.signal(298209, 2, 2 * 1000); -- NPC: an_ukun_biledrinker
 end
 
 function Ukun_Signal(e)
-  -- When we get a signal fromt he controller wake the dogs up.
-  e.self:ProcessSpecialAbilities(Ukun_Active);
+	if e.signal == 1 then
+ 		-- When we get a signal fromt he controller wake the dogs up.
+		e.self:ProcessSpecialAbilities(Ukun_Active);
+	elseif e.signal == 2 then
+		e.self:SetAppearance(3); -- Dead
+	end
 end
 
 function event_encounter_load(e)
-  eq.register_npc_event('tmcv', Event.spawn,          298014, Tunat_First_Spawn);
-  eq.register_npc_event('tmcv', Event.death_complete, 298014, Tunat_First_Death);
-  eq.register_npc_event('tmcv', Event.hp,             298014, Tunat_First_HP);
-  eq.register_npc_event('tmcv', Event.timer,          298014, Tunat_First_Timer);
-  eq.register_npc_event('tmcv', Event.combat,         298014, Tunat_First_Combat);
+	eq.register_npc_event("tmcv", Event.spawn,          298014, Tunat_First_Spawn);
+	eq.register_npc_event("tmcv", Event.death_complete, 298014, Tunat_First_Death);
+	eq.register_npc_event("tmcv", Event.hp,             298014, Tunat_First_HP);
+	eq.register_npc_event("tmcv", Event.timer,          298014, Tunat_First_Timer);
+	eq.register_npc_event("tmcv", Event.combat,         298014, Tunat_First_Combat);
 
-  eq.register_npc_event('tmcv', Event.spawn,          298055, Tunat_Second_Spawn);
-  eq.register_npc_event('tmcv', Event.combat,         298055, Tunat_Second_Combat);
-  eq.register_npc_event('tmcv', Event.death_complete, 298055, Tunat_Second_Death);
-  eq.register_npc_event('tmcv', Event.hp,             298055, Tunat_Second_HP);
-  eq.register_npc_event('tmcv', Event.timer,          298055, Tunat_Second_Timer);
+	eq.register_npc_event("tmcv", Event.spawn,          298055, Tunat_Second_Spawn);
+	eq.register_npc_event("tmcv", Event.combat,         298055, Tunat_Second_Combat);
+	eq.register_npc_event("tmcv", Event.death_complete, 298055, Tunat_Second_Death);
+	eq.register_npc_event("tmcv", Event.hp,             298055, Tunat_Second_HP);
+	eq.register_npc_event("tmcv", Event.timer,          298055, Tunat_Second_Timer);
 
-  eq.register_npc_event('tmcv', Event.combat,         298113, LP_Combat);
-  eq.register_npc_event('tmcv', Event.death,          298113, LP_Death);
-  eq.register_npc_event('tmcv', Event.timer,          298113, LP_Timer);
+	eq.register_npc_event("tmcv", Event.combat,         298113, LP_Combat);
+	eq.register_npc_event("tmcv", Event.death,          298113, LP_Death);
+	eq.register_npc_event("tmcv", Event.timer,          298113, LP_Timer);
 
-  eq.register_npc_event('tmcv', Event.spawn,          298209, Ukun_Spawn);
-  eq.register_npc_event('tmcv', Event.signal,         298209, Ukun_Signal);
+	eq.register_npc_event("tmcv", Event.spawn,          298209, Ukun_Spawn);
+	eq.register_npc_event("tmcv", Event.signal,         298209, Ukun_Signal);
 end

--- a/tacvi/encounters/tmcv.lua
+++ b/tacvi/encounters/tmcv.lua
@@ -226,7 +226,7 @@ end
 
 function Tunat_First_Death(e)
 	eq.zone_emote(0, "Tunat`Muram Cuu Vauax says, 'In an explosion of energy, Tunat'Muram Cuu Vauax disappears while ancient pebbles pelt against your armor.'");
-	eq.zone_emote(15,"The room is filled with an eerie laugh. 'You have done well to defeat my doppelganger and have shown great strength by making it this far, but I'm afraid I must end your struggle here. Your days have been numbered since you first set foot upon this continent and your time is up. Kneel before me and I will grant you a quick death, but resist and you will suffer in ways that will be spoken about in hushed tones for eons to come.");
+	eq.zone_emote(MT.Yellow,"The room is filled with an eerie laugh. 'You have done well to defeat my doppelganger and have shown great strength by making it this far, but I'm afraid I must end your struggle here. Your days have been numbered since you first set foot upon this continent and your time is up. Kneel before me and I will grant you a quick death, but resist and you will suffer in ways that will be spoken about in hushed tones for eons to come.");
 	eq.spawn2(298055,0,0, 309, -170.8, 21.3, 118.8); -- NPC: #Tunat`Muram_Cuu_Vauax
 	eq.depop_all(298113);
 	eq.depop_all(298209);
@@ -294,7 +294,7 @@ function Tunat_Second_Timer(e)
 		eq.set_timer("zmkp_powerup_repeat", 35 * 1000);		
 	elseif e.timer == "zmkp_powerup_repeat" then
 		-- Scale up each cycle - +700  max hit / +188 min hit
-		eq.zone_emote(15,"Zun`Muram Kvxe Pirik focuses his will and grows stronger.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Kvxe Pirik focuses his will and grows stronger.");
 		zmkp_min = zmkp_min + 188;
 		eq.modify_npc_stat("min_hit", tostring(zmkp_min));
 		zmkp_max = zmkp_max + 700;
@@ -304,28 +304,28 @@ function Tunat_Second_Timer(e)
 		eq.spawn2(298050, 0, 0, 334, -117, 21, 280); -- NPC: Zun`Muram_Mordl_Delt
 		eq.spawn2(298050, 0, 0, 356, -154, 21, 356); -- NPC: Zun`Muram_Mordl_Delt
 	elseif e.timer == "zmsb_rage" then
-		eq.zone_emote(15,"Zun`Muram Shaldn Boc starts to foam at the mouth as he enters a blind rage.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Shaldn Boc starts to foam at the mouth as he enters a blind rage.");
 		eq.stop_timer("zmsb_rage");
 		e.self:ModifyNPCStat("attack_delay","9");
 		eq.modify_npc_stat("min_hit", "2010");
 		eq.modify_npc_stat("max_hit", "6200");
 		eq.set_timer("zmsb_rage_over", 25 * 1000);
 	elseif e.timer == "zmsb_rage_over" then
-		eq.zone_emote(15,"Zun`Muram Shaldn Boc looks weakened as the rage ends.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Shaldn Boc looks weakened as the rage ends.");
 		eq.stop_timer("zmsb_rage_over");
 		e.self:ModifyNPCStat("attack_delay","15");
 		eq.modify_npc_stat("min_hit", "1462");
 		eq.modify_npc_stat("max_hit", "4700");
 		eq.set_timer("zmsb_rage", 30 * 1000);
 	elseif e.timer == "tunat_rage" then
-		eq.zone_emote(15,"Tunat`Muram Cuu Vuaux starts to foam at the mouth as he enters a blind rage.");
+		eq.zone_emote(MT.Yellow,"Tunat`Muram Cuu Vuaux starts to foam at the mouth as he enters a blind rage.");
 		eq.stop_timer("tunat_rage");
 		e.self:ModifyNPCStat("attack_delay","9");
 		eq.modify_npc_stat("min_hit", "1990");
 		eq.modify_npc_stat("max_hit", "5800");
 		eq.set_timer("tunat_rage_over", 25 * 1000);
 	elseif e.timer == "tunat_rage_over" then
-		eq.zone_emote(15,"Tunat`Muram Cuu Vuaux looks weakened as the rage ends.");
+		eq.zone_emote(MT.Yellow,"Tunat`Muram Cuu Vuaux looks weakened as the rage ends.");
 		eq.stop_timer("tunat_rage_over");
 		e.self:ModifyNPCStat("attack_delay","15");
 		eq.modify_npc_stat("min_hit", "1450");

--- a/tacvi/encounters/zmkp.lua
+++ b/tacvi/encounters/zmkp.lua
@@ -1,63 +1,3 @@
---[[
---
---  Tacvi Zun`Muram Kvxe Pirik Encounter
---  298029
---  http://everquest.allakhazam.com/db/quest.html?quest=4263
---
--- Zun`Muram Kvxe Pirik says 'Come you fools! Show me your strongest warrior and I will show you my first victim.'
---
---
--- Room Setup & Fight Details
---
--- In the room, you'll see Zun`Muram Kvxe Pirik surrounded by four aneuks:
---
--- - Balance of Defense
--- - Balance of Fury
--- - Balance of Rage
--- - Balance of Speed
---
--- Zun`Muram Kvxe Pirik hits for a max ~4,800 (can increase if you mess up the aneuks - more on this in a moment); single-target rampages; flurries; sees invisibility; does not see Shroud of Stealth. Upon engaging the encounter, the doors to the chamber seal shut.
---
---
--- Meditative States
---
--- At 90% (and again at 80%, 70%, 60%, 50%, 40% and 30%), Zun`Muram Kvxe Pirik goes non-aggro and enters a meditative state:
---
--- Kvxe enters a state of battle meditation.
---
--- At this point, you must DPS each Balance down so that their health matches Kvxe Pirik's health. If you succeed, the aneuk balances will 'tip in your favor':
---
--- Balance of _____ seems to be tipping in your favor.
---
--- Kvxe's body trembles as he fails to gather power from the balanced scales.
---
--- If you fail on one more balances, you will see:
---
--- Balance of _____ is falling out of balance.
---
--- Your failure to balance the scales has added to Kvxe's already impressive skills.
---
--- ...And Kvxe's skills will increase depending on which aneuk was out of balance. Don't fail too many times, otherwise the encounter becomes quite rough.
---
--- Balance of Speed - influences attack speed
--- Balance of Defense - influences mitigation and avoidance
--- Balance of Fury - influences chance to flurry
--- Balance of Rage - influences chance to rampage and its cooldown time
---
---
--- Zun`Muram Kvxe Pirik at 20%
---
--- At about 20% health, he increases his attack speed somewhat:
---
--- Kvxe enters a state of seething rage as he accelerates his combat speed.
---
---
--- Completion & Loot
---
--- Zun`Muram Kvxe Pirik has been slain by _____!
---
--- The creature's two heads face each other just before it falls to the floor, shaking the very foundation of the temple. Now there is nothing that stands between you and the being in charge of this invading army.
---]]
 local ZMKP_Active = "1,1^2,1^3,1^5,1^7,1^13,1^14,1^15,1^16,1^17,1^21,1^42,1";
 local ZMKP_Inactive = "19,1^20,1^21,1^24,1^25,1";
 
@@ -69,335 +9,321 @@ local ZMKP_Delay  = 20;
 
 -- Time out on Balancing seemed to be about 70 seconds
 local ZMKP_Balance_Timer = 70 * 1000;
-
 local ZMKP_Fury = 100;
 local ZMKP_Rage = 100;
 local ZMKP_Speed = 100;
 local ZMKP_Defense = 100;
-
 local target_hp = 90;
-
 local defense_balanced = false;
 local fury_balanced = false;
 local rage_balanced = false;
 local speed_balanced = false;
 
 function ZMKP_Spawn(e)
-  eq.spawn2(298125, 0, 0, 412.0, -714.0, -4.125, 454); -- NPC: #Balance_of_Speed
-  eq.spawn2(298126, 0, 0, 339.0, -714.0, -4.125, 88); -- NPC: #Balance_of_Defense
-  eq.spawn2(298127, 0, 0, 412.0, -646.0, -4.125, 318); -- NPC: #Balance_of_Fury
-  eq.spawn2(298128, 0, 0, 339.0, -646.0, -4.125, 190); -- NPC: #Balance_of_Rage
+	eq.spawn2(298125, 0, 0, 412.0, -714.0, -4.125, 454); -- NPC: #Balance_of_Speed
+	eq.spawn2(298126, 0, 0, 339.0, -714.0, -4.125, 88); -- NPC: #Balance_of_Defense
+	eq.spawn2(298127, 0, 0, 412.0, -646.0, -4.125, 318); -- NPC: #Balance_of_Fury
+	eq.spawn2(298128, 0, 0, 339.0, -646.0, -4.125, 190); -- NPC: #Balance_of_Rage
 
-  ZMKP_AC     = 568; -- Defense
-  ZMKP_MaxHit = 3900; -- Fury
-  ZMKP_MinHit = 1430;
-  ZMKP_AtkHit = 400; -- Rage
-  ZMKP_Delay  = 20;
+	ZMKP_AC     = 568; -- Defense
+	ZMKP_MaxHit = 3900; -- Fury
+	ZMKP_MinHit = 1430;
+	ZMKP_AtkHit = 400; -- Rage
+	ZMKP_Delay  = 20;
 
-  e.self:ModifyNPCStat("ac",            tostring(ZMKP_AC));
-  e.self:ModifyNPCStat("max_hit",       tostring(ZMKP_MaxHit));
-  e.self:ModifyNPCStat("min_hit",       tostring(ZMKP_MinHit));
-  e.self:ModifyNPCStat("atk",           tostring(ZMKP_AtkHit));
-  e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay));
-  eq.set_next_hp_event(90);
-  target_hp = 90;
+	e.self:ModifyNPCStat("ac",            tostring(ZMKP_AC));
+	e.self:ModifyNPCStat("max_hit",       tostring(ZMKP_MaxHit));
+	e.self:ModifyNPCStat("min_hit",       tostring(ZMKP_MinHit));
+	e.self:ModifyNPCStat("atk",           tostring(ZMKP_AtkHit));
+	e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay));
+	eq.set_next_hp_event(90);
+	target_hp = 90;
 end
 
 function ZMKP_Combat(e)
-  if (e.joined == true) then
-
-    e.self:Emote("Come you fools! Show me your strongest warrior and I will show you my first victim.");
-  else
-    eq.set_timer("wipecheck", 1 * 1000);
-  end
+	if e.joined then
+		e.self:Emote("Come you fools! Show me your strongest warrior and I will show you my first victim.");
+	else
+		eq.set_timer("wipecheck", 1 * 1000);
+	end
 end
 
 function ZMKP_Timer(e)
-  if (e.timer == 'balance') then
-    eq.stop_timer(e.timer);
-    eq.stop_timer("wipecheck");
-    eq.signal(298125, 1); -- NPC: #Balance_of_Speed
-    eq.signal(298126, 1); -- NPC: #Balance_of_Defense
-    eq.signal(298127, 1); -- NPC: #Balance_of_Fury
-    eq.signal(298128, 1); -- NPC: #Balance_of_Rage
+	if e.timer == 'balance' then
+		eq.stop_timer(e.timer);
+		eq.stop_timer("wipecheck");
+		eq.signal(298125, 1); -- NPC: #Balance_of_Speed
+		eq.signal(298126, 1); -- NPC: #Balance_of_Defense
+		eq.signal(298127, 1); -- NPC: #Balance_of_Fury
+		eq.signal(298128, 1); -- NPC: #Balance_of_Rage
 
-    local failed = false;
+		local failed = false;
 
-    if (not speed_balanced) then
-      -- Reduce ZMKP's Attack Delay by 10% each time the Speed mob is out of Balance.
-      ZMKP_Delay = ZMKP_Delay * 0.90;
-      e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay));
-      failed = true;
-    end
-    if (not defense_balanced) then
-      ZMKP_AC = ZMKP_AC + 100;
-      e.self:ModifyNPCStat("ac",            tostring(ZMKP_AC));
-      failed = true;
-    end
-    if (not fury_balanced) then
-      ZMKP_MaxHit = ZMKP_MaxHit + 585;
-      ZMKP_MinHit = ZMKP_MinHit + 215;
-      e.self:ModifyNPCStat("max_hit",       tostring(ZMKP_MaxHit));
-      e.self:ModifyNPCStat("min_hit",       tostring(ZMKP_MinHit));
-      failed = true;
-    end
-    if (not rage_balanced) then
-      ZMKP_AtkHit = ZMKP_AtkHit + 200;
-      e.self:ModifyNPCStat("atk",           tostring(ZMKP_AtkHit));
-      failed = true;
-    end
+		if not speed_balanced then
+			-- Reduce ZMKP's Attack Delay by 10% each time the Speed mob is out of Balance.
+			ZMKP_Delay = ZMKP_Delay * 0.90;
+			e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay));
+			failed = true;
+		end
+		if not defense_balanced then
+			ZMKP_AC = ZMKP_AC + 100;
+			e.self:ModifyNPCStat("ac",            tostring(ZMKP_AC));
+			failed = true;
+		end
+		if not fury_balanced then
+			ZMKP_MaxHit = ZMKP_MaxHit + 585;
+			ZMKP_MinHit = ZMKP_MinHit + 215;
+			e.self:ModifyNPCStat("max_hit",       tostring(ZMKP_MaxHit));
+			e.self:ModifyNPCStat("min_hit",       tostring(ZMKP_MinHit));
+			failed = true;
+		end
+		if not rage_balanced then
+			ZMKP_AtkHit = ZMKP_AtkHit + 200;
+			e.self:ModifyNPCStat("atk",           tostring(ZMKP_AtkHit));
+			failed = true;
+		end
 
-    if (failed) then
-      eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Your failure to balance the scales has added to Kvxe's already impressive skills.");
-    else
-      eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe's body trembles as he fails to gather power from the balanced scales.");
-    end
+		if failed then
+			eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Your failure to balance the scales has added to Kvxe's already impressive skills.");
+		else
+			eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe's body trembles as he fails to gather power from the balanced scales.");
+		end
 
-    -- so dots will oddly still hurt him, with enough necros it is possible to skip an event if we just used HP events (live doesn't skip, probably does if you manage to kill him though)
-    -- So instead of just using straight HP events, we gotta do some checking here!
-    if (math.floor(e.self:GetHPRatio()) <= (target_hp - 10)) then
-        -- we'll we gotta skip an active phase basically, to next balance!
-        eq.set_timer("balance", ZMKP_Balance_Timer);
-        eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
-        e.self:SetOOCRegen(0);
-        target_hp = target_hp - 10;
+		-- so dots will oddly still hurt him, with enough necros it is possible to skip an event if we just used HP events (live doesn't skip, probably does if you manage to kill him though)
+		-- So instead of just using straight HP events, we gotta do some checking here!
+		if math.floor(e.self:GetHPRatio()) <= (target_hp - 10) then
+				-- we'll we gotta skip an active phase basically, to next balance!
+				eq.set_timer("balance", ZMKP_Balance_Timer);
+				eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
+				e.self:SetOOCRegen(0);
+				target_hp = target_hp - 10;
 
-        eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-        eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-        eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-        eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-    else
-        e.self:ProcessSpecialAbilities(ZMKP_Active);
-        target_hp = target_hp - 10;
-        eq.set_next_hp_event(target_hp);
-    end
-  elseif (e.timer == "wipecheck") then
-    -- Check to see if there are any Clients in the room with ZMKP
-    local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 9000);
-    if (client:IsClient() == false) then
-      -- Clean up after a wipe
-      eq.depop_all(298125);
-      eq.depop_all(298126);
-      eq.depop_all(298127);
-      eq.depop_all(298128);
+				eq.signal(298125, 2); -- NPC: #Balance_of_Speed
+				eq.signal(298126, 2); -- NPC: #Balance_of_Defense
+				eq.signal(298127, 2); -- NPC: #Balance_of_Fury
+				eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+		else
+				e.self:ProcessSpecialAbilities(ZMKP_Active);
+				target_hp = target_hp - 10;
+				eq.set_next_hp_event(target_hp);
+		end
+	elseif e.timer == "wipecheck" then
+		-- Check to see if there are any Clients in the room with ZMKP
+		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 9000);
+		if not client:IsClient() then
+			-- Clean up after a wipe
+			eq.depop_all(298125);
+			eq.depop_all(298126);
+			eq.depop_all(298127);
+			eq.depop_all(298128);
 
-      eq.spawn2(298029, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()); -- NPC: Zun`Muram_Kvxe_Pirik
-      eq.depop();
+			eq.spawn2(298029, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()); -- NPC: Zun`Muram_Kvxe_Pirik
+			eq.depop();
 
-      eq.get_entity_list():FindDoor(16):SetLockPick(0);
-    end
-  end
+			eq.signal(298223,2); -- Unlock Doors
+		end
+	end
 end
 
 function ZMKP_Hp(e)
-  if (e.hp_event == 90) then
-    eq.get_entity_list():FindDoor(16):SetLockPick(-1);
+	if e.hp_event == 90 then
+		eq.signal(298223,1); -- Lock Doors
 
-    eq.set_timer("balance", ZMKP_Balance_Timer);
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
-    e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-    e.self:SetOOCRegen(0);
-    e.self:WipeHateList();
+		eq.set_timer("balance", ZMKP_Balance_Timer);
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
+		e.self:SetOOCRegen(0);
+		e.self:WipeHateList();
 
-    eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-    eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-    eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-    eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
+		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
+		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
+		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+	elseif e.hp_event == 80 then
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
+		eq.set_timer("balance", ZMKP_Balance_Timer);
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
+		e.self:SetOOCRegen(0);
+		e.self:WipeHateList();
 
-  elseif (e.hp_event == 80) then
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
-    eq.set_timer("balance", ZMKP_Balance_Timer);
-    e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-    e.self:SetOOCRegen(0);
-    e.self:WipeHateList();
+		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
+		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
+		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
+		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+	elseif e.hp_event == 70 then
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
+		eq.set_timer("balance", ZMKP_Balance_Timer);
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
+		e.self:SetOOCRegen(0);
+		e.self:WipeHateList();
 
-    eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-    eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-    eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-    eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
+		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
+		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
+		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+	elseif e.hp_event == 60 then
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
+		eq.set_timer("balance", ZMKP_Balance_Timer);
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
+		e.self:SetOOCRegen(0);
+		e.self:WipeHateList();
 
-  elseif (e.hp_event == 70) then
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
-    eq.set_timer("balance", ZMKP_Balance_Timer);
-    e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-    e.self:SetOOCRegen(0);
-    e.self:WipeHateList();
+		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
+		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
+		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
+		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+	elseif e.hp_event == 50 then
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
+		eq.set_timer("balance", ZMKP_Balance_Timer);
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
+		e.self:SetOOCRegen(0);
+		e.self:WipeHateList();
 
-    eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-    eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-    eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-    eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
+		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
+		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
+		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+	elseif e.hp_event == 40 then
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
+		eq.set_timer("balance", ZMKP_Balance_Timer);
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
+		e.self:SetOOCRegen(0);
+		e.self:WipeHateList();
 
-  elseif (e.hp_event == 60) then
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
-    eq.set_timer("balance", ZMKP_Balance_Timer);
-    e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-    e.self:SetOOCRegen(0);
-    e.self:WipeHateList();
+		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
+		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
+		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
+		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+	elseif e.hp_event == 30 then
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
+		eq.set_timer("balance", ZMKP_Balance_Timer);
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
+		e.self:SetOOCRegen(0);
+		e.self:WipeHateList();
 
-    eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-    eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-    eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-    eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-
-  elseif (e.hp_event == 50) then
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
-    eq.set_timer("balance", ZMKP_Balance_Timer);
-    e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-    e.self:SetOOCRegen(0);
-    e.self:WipeHateList();
-
-    eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-    eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-    eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-    eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-
-  elseif (e.hp_event == 40) then
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
-    eq.set_timer("balance", ZMKP_Balance_Timer);
-    e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-    e.self:SetOOCRegen(0);
-    e.self:WipeHateList();
-
-    eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-    eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-    eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-    eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-
-  elseif (e.hp_event == 30) then
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of battle meditation.");
-    eq.set_timer("balance", ZMKP_Balance_Timer);
-    e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-    e.self:SetOOCRegen(0);
-    e.self:WipeHateList();
-
-    eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-    eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-    eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-    eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-
-  elseif (e.hp_event == 20) then
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of seething rage as he accelerates his combat speed.");
-    ZMKP_Delay = ZMKP_Delay * 0.90;
-    e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay));
-  end
+		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
+		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
+		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
+		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+	elseif e.hp_event == 20 then
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, "Kvxe enters a state of seething rage as he accelerates his combat speed.");
+		ZMKP_Delay = ZMKP_Delay * 0.90;
+		e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay));
+	end
 end
 
 function ZMKP_Signal(e)
 end
 
 function ZMKP_Death(e)
-  eq.signal(298223, 298029); -- NPC: zone_status
+	eq.signal(298223, 298029); -- NPC: zone_status
 
-  eq.depop_all(298125);
-  eq.depop_all(298126);
-  eq.depop_all(298127);
-  eq.depop_all(298128);
-  eq.get_entity_list():FindDoor(16):SetLockPick(0);
+	eq.depop_all(298125);
+	eq.depop_all(298126);
+	eq.depop_all(298127);
+	eq.depop_all(298128);
+	eq.signal(298223,2,1000); -- Unlock Doors
 end
 
 function ZMKP_Spawn_Speed(e)
-  e.self:SetOOCRegen(0);
+	e.self:SetOOCRegen(0);
 end
 
 function ZMKP_Spawn_Defense(e)
-  e.self:SetOOCRegen(0);
+	e.self:SetOOCRegen(0);
 end
 
 function ZMKP_Spawn_Fury(e)
-  e.self:SetOOCRegen(0);
+	e.self:SetOOCRegen(0);
 end
 
 function ZMKP_Spawn_Rage(e)
-  e.self:SetOOCRegen(0);
+	e.self:SetOOCRegen(0);
 end
 
 function ZMKP_Signal_Balance(e)
-  if (e.signal == 1) then
-    e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-    e.self:SetHP(e.self:GetMaxHP());
-    e.self:WipeHateList();
+	if e.signal == 1 then
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
+		e.self:SetHP(e.self:GetMaxHP());
+		e.self:WipeHateList();
 
-    -- lets double check
-    if (e.self:GetHPRatio() <= (target_hp - 3)) then
-      local id = e.self:GetNPCTypeID();
-      if (id == 298125) then
-        speed_balanced = false;
-      elseif (id == 298126) then
-        defense_balanced = false;
-      elseif (id == 298127) then
-        fury_balanced = false;
-      elseif (id == 298128) then
-        rage_balanced = false;
-      end
-      eq.get_entity_list():MessageClose(e.self, false, 120, 15, e.self:GetCleanName() .. " is falling out of balance.");
-    end
-  elseif (e.signal == 2) then
-    defense_balanced = false;
-    fury_balanced = false;
-    rage_balanced = false;
-    speed_balanced = false;
+		-- lets double check
+		if e.self:GetHPRatio() <= (target_hp - 3) then
+			local id = e.self:GetNPCTypeID();
+			if id == 298125 then
+				speed_balanced = false;
+			elseif id == 298126 then
+				defense_balanced = false;
+			elseif id == 298127 then
+				fury_balanced = false;
+			elseif id == 298128 then
+				rage_balanced = false;
+			end
+			eq.get_entity_list():MessageClose(e.self, false, 120, 15, e.self:GetCleanName() .. " is falling out of balance.");
+		end
+	elseif e.signal == 2 then
+		defense_balanced = false;
+		fury_balanced = false;
+		rage_balanced = false;
+		speed_balanced = false;
 
-    eq.set_next_hp_event(target_hp + 3);
-    e.self:ProcessSpecialAbilities("42,1")
-    e.self:SetHP(e.self:GetMaxHP());
-    e.self:WipeHateList();
-  end
+		eq.set_next_hp_event(target_hp + 3);
+		e.self:ProcessSpecialAbilities("42,1")
+		e.self:SetHP(e.self:GetMaxHP());
+		e.self:WipeHateList();
+	end
 end
 
 function ZMKP_Hp_Balance(e)
-  if (e.hp_event == (target_hp + 3)) then
-    local id = e.self:GetNPCTypeID();
-    if (id == 298125) then
-      speed_balanced = true;
-    elseif (id == 298126) then
-      defense_balanced = true;
-    elseif (id == 298127) then
-      fury_balanced = true;
-    elseif (id == 298128) then
-      rage_balanced = true;
-    end
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, e.self:GetCleanName() .. " seems to be tipping in your favor.");
-    eq.set_next_hp_event(target_hp - 3)
-  elseif (e.hp_event == (target_hp - 3)) then
-    local id = e.self:GetNPCTypeID();
-    if (id == 298125) then
-      speed_balanced = false;
-    elseif (id == 298126) then
-      defense_balanced = false;
-    elseif (id == 298127) then
-      fury_balanced = false;
-    elseif (id == 298128) then
-      rage_balanced = false;
-    end
-    eq.get_entity_list():MessageClose(e.self, false, 120, 15, e.self:GetCleanName() .. " is falling out of balance.");
-  end
+	if e.hp_event == (target_hp + 3) then
+		local id = e.self:GetNPCTypeID();
+		if id == 298125 then
+			speed_balanced = true;
+		elseif id == 298126 then
+			defense_balanced = true;
+		elseif id == 298127 then
+			fury_balanced = true;
+		elseif id == 298128 then
+			rage_balanced = true;
+		end
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, e.self:GetCleanName() .. " seems to be tipping in your favor.");
+		eq.set_next_hp_event(target_hp - 3)
+	elseif e.hp_event == (target_hp - 3) then
+		local id = e.self:GetNPCTypeID();
+		if id == 298125 then
+			speed_balanced = false;
+		elseif id == 298126 then
+			defense_balanced = false;
+		elseif id == 298127 then
+			fury_balanced = false;
+		elseif id == 298128 then
+			rage_balanced = false;
+		end
+		eq.get_entity_list():MessageClose(e.self, false, 120, 15, e.self:GetCleanName() .. " is falling out of balance.");
+	end
 end
 
 function event_encounter_load(e)
-  eq.register_npc_event('zmkp', Event.spawn,          298029, ZMKP_Spawn);
-  eq.register_npc_event('zmkp', Event.combat,         298029, ZMKP_Combat);
-  eq.register_npc_event('zmkp', Event.timer,          298029, ZMKP_Timer);
-  eq.register_npc_event('zmkp', Event.hp,             298029, ZMKP_Hp);
-  eq.register_npc_event('zmkp', Event.signal,         298029, ZMKP_Signal);
-  eq.register_npc_event('zmkp', Event.say,            298029, ZMKP_Say);
-  eq.register_npc_event('zmkp', Event.death_complete, 298029, ZMKP_Death);
+	eq.register_npc_event('zmkp', Event.spawn,          298029, ZMKP_Spawn);
+	eq.register_npc_event('zmkp', Event.combat,         298029, ZMKP_Combat);
+	eq.register_npc_event('zmkp', Event.timer,          298029, ZMKP_Timer);
+	eq.register_npc_event('zmkp', Event.hp,             298029, ZMKP_Hp);
+	eq.register_npc_event('zmkp', Event.signal,         298029, ZMKP_Signal);
+	eq.register_npc_event('zmkp', Event.say,            298029, ZMKP_Say);
+	eq.register_npc_event('zmkp', Event.death_complete, 298029, ZMKP_Death);
 
-  eq.register_npc_event('zmkp', Event.spawn,          298125, ZMKP_Spawn_Speed);
-  eq.register_npc_event('zmkp', Event.spawn,          298126, ZMKP_Spawn_Defense);
-  eq.register_npc_event('zmkp', Event.spawn,          298127, ZMKP_Spawn_Fury);
-  eq.register_npc_event('zmkp', Event.spawn,          298128, ZMKP_Spawn_Rage);
+	eq.register_npc_event('zmkp', Event.spawn,          298125, ZMKP_Spawn_Speed);
+	eq.register_npc_event('zmkp', Event.spawn,          298126, ZMKP_Spawn_Defense);
+	eq.register_npc_event('zmkp', Event.spawn,          298127, ZMKP_Spawn_Fury);
+	eq.register_npc_event('zmkp', Event.spawn,          298128, ZMKP_Spawn_Rage);
 
-  eq.register_npc_event('zmkp', Event.signal,         298125, ZMKP_Signal_Balance);
-  eq.register_npc_event('zmkp', Event.signal,         298126, ZMKP_Signal_Balance);
-  eq.register_npc_event('zmkp', Event.signal,         298127, ZMKP_Signal_Balance);
-  eq.register_npc_event('zmkp', Event.signal,         298128, ZMKP_Signal_Balance);
+	eq.register_npc_event('zmkp', Event.signal,         298125, ZMKP_Signal_Balance);
+	eq.register_npc_event('zmkp', Event.signal,         298126, ZMKP_Signal_Balance);
+	eq.register_npc_event('zmkp', Event.signal,         298127, ZMKP_Signal_Balance);
+	eq.register_npc_event('zmkp', Event.signal,         298128, ZMKP_Signal_Balance);
 
-  eq.register_npc_event('zmkp', Event.hp,             298125, ZMKP_Hp_Balance);
-  eq.register_npc_event('zmkp', Event.hp,             298126, ZMKP_Hp_Balance);
-  eq.register_npc_event('zmkp', Event.hp,             298127, ZMKP_Hp_Balance);
-  eq.register_npc_event('zmkp', Event.hp,             298128, ZMKP_Hp_Balance);
-end
-
-function event_encounter_unload(e)
+	eq.register_npc_event('zmkp', Event.hp,             298125, ZMKP_Hp_Balance);
+	eq.register_npc_event('zmkp', Event.hp,             298126, ZMKP_Hp_Balance);
+	eq.register_npc_event('zmkp', Event.hp,             298127, ZMKP_Hp_Balance);
+	eq.register_npc_event('zmkp', Event.hp,             298128, ZMKP_Hp_Balance);
 end

--- a/tacvi/encounters/zmmd.lua
+++ b/tacvi/encounters/zmmd.lua
@@ -1,182 +1,152 @@
---[[
--- Zun`Muram Mordl Delt ZMMD
--- 298020
--- http://everquest.allakhazam.com/db/quest.html?quest=4265
---
--- Zun`Muram Mordl Delt says 'Come you fools! Show me your strongest warrior and I will show you my first victim.'
---
---
--- The Encounter
---
--- Zun`Muram Mordl Delt hits for a max ~4,800 and single-target rampages.
---
--- During the encounter, he splits into multiple versions of himself (wouldn't this be convenient in everyday life).
---
--- At 90% health, the real "Zun`Muram Mordl Delt" feigns death and two clones of him spawn and attack:
---
--- Zun'Muram Mordl Delt's skin begins to bulge and split open, releasing a wave of energy. As his body falls to the floor, two smaller images of the massive creature appear before you.
---
--- The clones each hit for a max ~3,700 and should be kited until they despawn (this takes a few minutes):
---
--- Zun'Muram Mordl Delt's body begins to glow as the images before you merge back into one. The wounds upon Mordl's body quickly heal as he's infused by the energy, but new wounds appear where his other forms were injured.
---
--- At 70% health, he feigns death again and spawns three clones which, again, should be kited until they despawn.
---
--- He does this again at 50% (four clones to be kited until despawn).
---
--- At 30%, he spawns two clones (weaker in power), but this time, doesn't feign death. Here, he needs to be killed while you kite and/or offtank the two clones.
---
--- In a final act of desperation, Mordl splits two smaller forms off from himself but looks visibly drained by the effort.
---
--- NOTE: In all cases, and if your raid force can withstand it, you can kill the clones instead of kiting them.
---
---
--- Completion & Loot
---
--- Zun`Muram Mordl Delt has been slain by _____!
--- The creature's two heads face each other just before it falls to the floor, shaking the very foundation of the temple. Now there is nothing that stands between you and the being in charge of this invading army.
---
--- The chamber is filled with the sound of a grinding stone. The path leading into the final chamber has been opened and it awaits your arrival. You hear a voice that sounds oddly familiar. 'Come now, fools, enter my chamber and learn the meaning of suffering from one bred to destroy and conquer. You have beaten the best of my army, but you have yet to see true power. Step into the abyss and cower at what stares back at you.'
---
---]]
 local ZMMD_Active = "1,1^2,1^3,1^5,1^7,1^13,1^14,1^15,1^16,1^17,1^21,1^42,1"; 
 local ZMMD_Inactive = "18,1^19,1^20,1^21,1^24,1^25,1";
+local hp_event = 0;
+local adds_killed = 0;
+local hp_array = {
+	[90] = {0.81, 0.71},
+	[70] = {0.65, 0.58, 0.51},
+	[50] = {0.47, 0.42, 0.37, 0.31}
+}
 
--- Youtube Video indicated a ~3min kite
 local kite_time = 180;
 
 function ZMMD_Spawn(e)
-  eq.set_next_hp_event(90);
+	eq.set_next_hp_event(90);
 end
 
 function ZMMD_Combat(e)
-  if (e.joined == true) then
-
-    e.self:Say("Come you fools! Show me your strongest warrior and I will show you my first victim.");
-  else
-    eq.set_timer("wipecheck", 1 * 1000);
-  end
+	if e.joined then
+		e.self:Say("Come you fools! Show me your strongest warrior and I will show you my first victim.");
+	else
+		eq.set_timer("wipecheck", 1 * 1000);
+	end
 end
 
 function ZMMD_Activate(e)
-  e.self:Emote("'s body begins to glow as the images before you merge back into one. The wounds upon Mordl's body quickly heal as he's infused by the energy, but new wounds appear where his other forms were injured. ");
-  e.self:ProcessSpecialAbilities(ZMMD_Active);
-  e.self:SetAppearance(0);
-  eq.stop_timer("wipecheck");
+	-- Damage ZMMD based on adds killed out of adds spawned.
+	if adds_killed > 0 and hp_event > 0 then
+		e.self:SetHP(e.self:GetMaxHP() * tonumber(hp_array[hp_event][adds_killed]));
+	end
+
+	e.self:Emote("'s body begins to glow as the images before you merge back into one. The wounds upon Mordl's body quickly heal as he's infused by the energy, but new wounds appear where his other forms were injured. ");
+	e.self:ProcessSpecialAbilities(ZMMD_Active);
+	e.self:SetAppearance(0);
+	eq.stop_timer("wipecheck");
 end
 
 function ZMMD_Inactivate(e)
-  e.self:ProcessSpecialAbilities(ZMMD_Inactive);
-  e.self:SetAppearance(3);
-  e.self:WipeHateList();
-  e.self:SetOOCRegen(0);
+	e.self:ProcessSpecialAbilities(ZMMD_Inactive);
+	e.self:SetAppearance(3);
+	e.self:WipeHateList();
+	e.self:SetOOCRegen(0);
 end
 
 function ZMMD_Timer(e)
-  if (e.timer == "zmmd_kite") then
-    eq.stop_timer(e.timer);
-      eq.depop_all(298050);
-      eq.depop_all(298051);
-      eq.depop_all(298052);
-    ZMMD_Activate(e);
-  elseif ("wipecheck") then
-    -- Check to see if there are any Clients in the room with ZMKP
-    local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 8000);
-    if (client:IsClient() == false) then
-      -- Wipe Mechanics
-      eq.get_entity_list():FindDoor(13):SetLockPick(0);
-      eq.depop_all(298050);
-      eq.depop_all(298051);
-      eq.depop_all(298052);
-      eq.depop_all(298053);
-      eq.spawn2(298020, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()); -- NPC: Zun`Muram_Mordl_Delt
-      eq.depop();
-    end
-  end
+	if e.timer == "zmmd_kite" then
+		eq.stop_timer(e.timer);
+			eq.depop_all(298050);
+			eq.depop_all(298051);
+			eq.depop_all(298052);
+		ZMMD_Activate(e);
+	elseif e.timer == "wipecheck" then
+		-- Check to see if there are any Clients in the room with ZMKP
+		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 8000);
+		if (client:IsClient() == false) then
+			-- Wipe Mechanics
+			eq.signal(298223,2); -- Unlock Doors
+			eq.depop_all(298050);
+			eq.depop_all(298051);
+			eq.depop_all(298052);
+			eq.depop_all(298053);
+			eq.spawn2(298020, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()); -- NPC: Zun`Muram_Mordl_Delt
+			eq.depop();
+		end
+	end
 end
 
 function ZMMD_Hp(e)
-  if (e.hp_event == 90) then
-    eq.get_entity_list():FindDoor(13):SetLockPick(-1);
-    eq.zone_emote(15,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing a wave of energy. As his body falls to the floor, two smaller images of the massive creature appear before you.");
-    
+	hp_event = e.hp_event;
+	if e.hp_event == 90 then
+		eq.signal(298223,1); -- Lock Doors
 
-    eq.set_next_hp_event(70);
+		eq.zone_emote(15,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing a wave of energy. As his body falls to the floor, two smaller images of the massive creature appear before you.");
+		eq.set_next_hp_event(70);
 
-    ZMMD_Inactivate(e);
-    eq.spawn2(298050,0,0, 367, 130, -6.7, 370); -- NPC: Zun`Muram_Mordl_Delt
-    eq.spawn2(298050,0,0, 367, 151, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
+		ZMMD_Inactivate(e);
+		adds_killed = 0;
+		eq.spawn2(298050,0,0, 367, 130, -6.7, 370); -- NPC: Zun`Muram_Mordl_Delt
+		eq.spawn2(298050,0,0, 367, 151, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
 
-    eq.set_timer("zmmd_kite", kite_time * 1000);
+		eq.set_timer("zmmd_kite", kite_time * 1000);
 
-  elseif (e.hp_event == 70) then
-    eq.set_next_hp_event(50);
-    
-    eq.zone_emote(15,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing another wave of energy. Three smaller images of the massive creature appear before you as the previous form fades away.");
-    
-    ZMMD_Inactivate(e);
-    eq.spawn2(298051,0,0, 367, 130, -6.7, 370); -- NPC: Zun`Muram_Mordl_Delt
-    eq.spawn2(298051,0,0, 367, 151, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
-    eq.spawn2(298051,0,0, 367, 171, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
-    eq.set_timer("zmmd_kite", kite_time * 1000);
+	elseif e.hp_event == 70 then
+		eq.set_next_hp_event(50);
 
-  elseif (e.hp_event == 50) then
-    eq.set_next_hp_event(30);
+		eq.zone_emote(15,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing another wave of energy. Three smaller images of the massive creature appear before you as the previous form fades away.");
+		
+		ZMMD_Inactivate(e);
+		adds_killed = 0;
+		eq.spawn2(298051,0,0, 367, 130, -6.7, 370); -- NPC: Zun`Muram_Mordl_Delt
+		eq.spawn2(298051,0,0, 367, 151, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
+		eq.spawn2(298051,0,0, 367, 171, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
+		eq.set_timer("zmmd_kite", kite_time * 1000);
 
-    eq.zone_emote(15,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing another wave of energy. Four smaller images of the massive creature appear before you as the previous form fades away.");
-    
-    ZMMD_Inactivate(e);
-    eq.spawn2(298052,0,0, 367, 130, -6.7, 370); -- NPC: Zun`Muram_Mordl_Delt
-    eq.spawn2(298052,0,0, 367, 151, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
-    eq.spawn2(298052,0,0, 367, 170, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
-    eq.spawn2(298052,0,0, 367, 110, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
-    eq.set_timer("zmmd_kite", kite_time * 1000);
+	elseif e.hp_event == 50 then
+		eq.set_next_hp_event(30);
 
-  elseif (e.hp_event == 30) then
-    
-    eq.zone_emote(15,"Zun`Muram Mordl Delt's body begins to glow as the images before you merge back into one. The wounds upon Mordl's body quickly heal as he's infused by the energy, but new wounds appear where his other forms were injured.");
-    eq.zone_emote(15,"In a final act of desperation, Mordl splits two smaller forms off from himself but looks visibly drained from the effort.");
-    
-    eq.modify_npc_stat("min_hit", "1670");
-    eq.modify_npc_stat("max_hit", "4900");
-    eq.spawn2(298053,0,0, 367, 151, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
-    eq.spawn2(298053,0,0, 367, 171, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
+		eq.zone_emote(15,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing another wave of energy. Four smaller images of the massive creature appear before you as the previous form fades away.");
+		
+		ZMMD_Inactivate(e);
+		adds_killed = 0;
+		eq.spawn2(298052,0,0, 367, 130, -6.7, 370); -- NPC: Zun`Muram_Mordl_Delt
+		eq.spawn2(298052,0,0, 367, 151, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
+		eq.spawn2(298052,0,0, 367, 170, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
+		eq.spawn2(298052,0,0, 367, 110, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
+		eq.set_timer("zmmd_kite", kite_time * 1000);
 
-  end
-
+	elseif e.hp_event == 30 then
+		eq.zone_emote(15,"Zun`Muram Mordl Delt's body begins to glow as the images before you merge back into one. The wounds upon Mordl's body quickly heal as he's infused by the energy, but new wounds appear where his other forms were injured.");
+		eq.zone_emote(15,"In a final act of desperation, Mordl splits two smaller forms off from himself but looks visibly drained from the effort.");
+		
+		adds_killed = 0;
+		eq.modify_npc_stat("min_hit", "1670");
+		eq.modify_npc_stat("max_hit", "4900");
+		eq.spawn2(298053,0,0, 367, 151, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
+		eq.spawn2(298053,0,0, 367, 171, -6.7, 394); -- NPC: Zun`Muram_Mordl_Delt
+	end
 end
 
 function ZMMD_Signal(e)
-  if (e.signal == 1) then
-    ZMMD_Activate(e);
-  end
+	if e.signal == 1 then
+		ZMMD_Activate(e);
+	end
 end
 
 function ZMMD_Death(e)
-  eq.signal(298223, 298020); -- NPC: zone_status
-
-  eq.get_entity_list():FindDoor(13):SetLockPick(0);
+	eq.signal(298223, 298020); -- NPC: zone_status
+	eq.signal(298223,2,1000); -- Unlock Doors
 end
 
 function ZMMD_Add_Death(e)
-  if (eq.get_entity_list():IsMobSpawnedByNpcTypeID( 298050 ) == false
-    and eq.get_entity_list():IsMobSpawnedByNpcTypeID( 298051 ) == false
-    and eq.get_entity_list():IsMobSpawnedByNpcTypeID( 298052 ) == false) then
+	adds_killed = adds_killed + 1;
+	if not eq.get_entity_list():IsMobSpawnedByNpcTypeID(298050)
+		and not eq.get_entity_list():IsMobSpawnedByNpcTypeID(298051)
+		and not eq.get_entity_list():IsMobSpawnedByNpcTypeID(298052) then
 
-    -- Wake ZMMD Main Mob back up.
-    eq.signal(298020,1); -- NPC: Zun`Muram_Mordl_Delt
-  end
+		-- Wake ZMMD Main Mob back up.
+		eq.signal(298020,1); -- NPC: Zun`Muram_Mordl_Delt
+	end
 end
 
 function event_encounter_load(e)
-  eq.register_npc_event('zmmd', Event.spawn,          298020, ZMMD_Spawn);
-  eq.register_npc_event('zmmd', Event.combat,         298020, ZMMD_Combat);
-  eq.register_npc_event('zmmd', Event.timer,          298020, ZMMD_Timer);
-  eq.register_npc_event('zmmd', Event.hp,             298020, ZMMD_Hp);
-  eq.register_npc_event('zmmd', Event.signal,         298020, ZMMD_Signal);
-  eq.register_npc_event('zmmd', Event.death_complete, 298020, ZMMD_Death);
+	eq.register_npc_event('zmmd', Event.spawn,          298020, ZMMD_Spawn);
+	eq.register_npc_event('zmmd', Event.combat,         298020, ZMMD_Combat);
+	eq.register_npc_event('zmmd', Event.timer,          298020, ZMMD_Timer);
+	eq.register_npc_event('zmmd', Event.hp,             298020, ZMMD_Hp);
+	eq.register_npc_event('zmmd', Event.signal,         298020, ZMMD_Signal);
+	eq.register_npc_event('zmmd', Event.death_complete, 298020, ZMMD_Death);
 
-  eq.register_npc_event('zmmd', Event.death_complete, 298050, ZMMD_Add_Death);
-  eq.register_npc_event('zmmd', Event.death_complete, 298051, ZMMD_Add_Death);
-  eq.register_npc_event('zmmd', Event.death_complete, 298052, ZMMD_Add_Death);
+	eq.register_npc_event('zmmd', Event.death_complete, 298050, ZMMD_Add_Death);
+	eq.register_npc_event('zmmd', Event.death_complete, 298051, ZMMD_Add_Death);
+	eq.register_npc_event('zmmd', Event.death_complete, 298052, ZMMD_Add_Death);
 end

--- a/tacvi/encounters/zmmd.lua
+++ b/tacvi/encounters/zmmd.lua
@@ -69,7 +69,7 @@ function ZMMD_Hp(e)
 	if e.hp_event == 90 then
 		eq.signal(298223,1); -- Lock Doors
 
-		eq.zone_emote(15,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing a wave of energy. As his body falls to the floor, two smaller images of the massive creature appear before you.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing a wave of energy. As his body falls to the floor, two smaller images of the massive creature appear before you.");
 		eq.set_next_hp_event(70);
 
 		ZMMD_Inactivate(e);
@@ -82,7 +82,7 @@ function ZMMD_Hp(e)
 	elseif e.hp_event == 70 then
 		eq.set_next_hp_event(50);
 
-		eq.zone_emote(15,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing another wave of energy. Three smaller images of the massive creature appear before you as the previous form fades away.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing another wave of energy. Three smaller images of the massive creature appear before you as the previous form fades away.");
 		
 		ZMMD_Inactivate(e);
 		adds_killed = 0;
@@ -94,7 +94,7 @@ function ZMMD_Hp(e)
 	elseif e.hp_event == 50 then
 		eq.set_next_hp_event(30);
 
-		eq.zone_emote(15,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing another wave of energy. Four smaller images of the massive creature appear before you as the previous form fades away.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Mordl Delt's skin begins to bulge and split open, releasing another wave of energy. Four smaller images of the massive creature appear before you as the previous form fades away.");
 		
 		ZMMD_Inactivate(e);
 		adds_killed = 0;
@@ -105,8 +105,8 @@ function ZMMD_Hp(e)
 		eq.set_timer("zmmd_kite", kite_time * 1000);
 
 	elseif e.hp_event == 30 then
-		eq.zone_emote(15,"Zun`Muram Mordl Delt's body begins to glow as the images before you merge back into one. The wounds upon Mordl's body quickly heal as he's infused by the energy, but new wounds appear where his other forms were injured.");
-		eq.zone_emote(15,"In a final act of desperation, Mordl splits two smaller forms off from himself but looks visibly drained from the effort.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Mordl Delt's body begins to glow as the images before you merge back into one. The wounds upon Mordl's body quickly heal as he's infused by the energy, but new wounds appear where his other forms were injured.");
+		eq.zone_emote(MT.Yellow,"In a final act of desperation, Mordl splits two smaller forms off from himself but looks visibly drained from the effort.");
 		
 		adds_killed = 0;
 		eq.modify_npc_stat("min_hit", "1670");

--- a/tacvi/encounters/zmsb.lua
+++ b/tacvi/encounters/zmsb.lua
@@ -1,140 +1,129 @@
-
 function ZMSB_Spawn(e)
-  eq.set_next_hp_event(90);
+	eq.set_next_hp_event(90);
 end
 
 function ZMSB_Combat(e)
-  if (e.joined == true) then
-    e.self:Say("Come you fools! Show me your strongest warrior and I will show you my first victim.");
-    eq.set_timer("rage", 35 * 1000);
-    eq.stop_timer("reset");
-		if (e.self:GetHPRatio() < 90) then
+	if e.joined then
+		e.self:Say("Come you fools! Show me your strongest warrior and I will show you my first victim.");
+		eq.set_timer("rage", 35 * 1000);
+		eq.stop_timer("reset");
+		if e.self:GetHPRatio() < 90 then
 			eq.set_timer("check", 1 * 1000); -- set scorpion timer during wipe recovery if someone aggro's
 		end
-  else
-    -- Wipe Mechanics
-	eq.stop_timer("check");
-    eq.stop_timer("rage");
-	eq.stop_timer("rage_stop");
-	eq.set_timer("reset", 30 * 1000);
-	
-    --eq.spawn2(298018, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()); -- NPC: Zun`Muram_Shaldn_Boc
-    --eq.depop();
-  end
+	else
+		-- Wipe Mechanics
+		eq.stop_timer("check");
+		eq.stop_timer("rage");
+		eq.stop_timer("rage_stop");
+		eq.set_timer("reset", 30 * 1000);
+	end
 end
 
 function ZMSB_Timer(e)
-  if (e.timer == "rage_stop") then
-    eq.stop_timer("rage_stop");
-    eq.set_timer("rage", 35 * 1000);
-    eq.zone_emote(15,"Zun`Muram Shaldn Boc looks weakened as the rage ends.");
-    e.self:ModifyNPCStat("min_hit", "1470");
-    e.self:ModifyNPCStat("max_hit", "4700");
-  --attack delay to 1.9s
-    e.self:ModifyNPCStat("attack_delay","19");
-  
-  elseif (e.timer == "rage") then
+	if e.timer == "rage_stop" then
+		eq.stop_timer("rage_stop");
+		eq.set_timer("rage", 35 * 1000);
+		eq.zone_emote(15,"Zun`Muram Shaldn Boc looks weakened as the rage ends.");
+		e.self:ModifyNPCStat("min_hit", "1470");
+		e.self:ModifyNPCStat("max_hit", "4700");
+ 		--attack delay to 1.9s
+		e.self:ModifyNPCStat("attack_delay","19");
+	elseif e.timer == "rage" then
 		eq.stop_timer("rage");
 		eq.zone_emote(15,"Zun`Muram Shaldn Boc starts to foam at the mouth as he enters a blind rage.");
-		if (e.self:GetHPRatio() >= 90) then
-			--need to parse 100% rage
+		if e.self:GetHPRatio() >= 90 then
 			e.self:ModifyNPCStat("min_hit", "1520");
 			e.self:ModifyNPCStat("max_hit", "4850");
 			e.self:ModifyNPCStat("attack_delay","16");
 			eq.set_timer("rage_stop", 20 * 1000);
-		elseif (e.self:GetHPRatio() < 90 and e.self:GetHPRatio() >= 80) then
+		elseif e.self:GetHPRatio() < 90 and e.self:GetHPRatio() >= 80 then
 			e.self:ModifyNPCStat("min_hit", "1558");
 			e.self:ModifyNPCStat("max_hit", "4978");
 			e.self:ModifyNPCStat("attack_delay","15");
 			eq.set_timer("rage_stop", 20 * 1000);
-		elseif (e.self:GetHPRatio() < 80 and e.self:GetHPRatio() >= 70) then
+		elseif e.self:GetHPRatio() < 80 and e.self:GetHPRatio() >= 70 then
 			e.self:ModifyNPCStat("min_hit", "1612");
 			e.self:ModifyNPCStat("max_hit", "5127");
 			e.self:ModifyNPCStat("attack_delay","14");
 			eq.set_timer("rage_stop", 35 * 1000);
-		elseif (e.self:GetHPRatio() < 70 and e.self:GetHPRatio() >= 60) then
+		elseif e.self:GetHPRatio() < 70 and e.self:GetHPRatio() >= 60 then
 			e.self:ModifyNPCStat("min_hit", "1666");
 			e.self:ModifyNPCStat("max_hit", "5276");
 			e.self:ModifyNPCStat("attack_delay","13");
 			eq.set_timer("rage_stop", 35 * 1000);
-		elseif (e.self:GetHPRatio() < 60 and e.self:GetHPRatio() >= 50) then
+		elseif e.self:GetHPRatio() < 60 and e.self:GetHPRatio() >= 50 then
 			e.self:ModifyNPCStat("min_hit", "1721");
 			e.self:ModifyNPCStat("max_hit", "5426");
 			e.self:ModifyNPCStat("attack_delay","12");
 			eq.set_timer("rage_stop", 35 * 1000);
-		elseif (e.self:GetHPRatio() < 50 and e.self:GetHPRatio() >= 40) then
+		elseif e.self:GetHPRatio() < 50 and e.self:GetHPRatio() >= 40 then
 			e.self:ModifyNPCStat("min_hit", "1775");
 			e.self:ModifyNPCStat("max_hit", "5575");
 			e.self:ModifyNPCStat("attack_delay","12");
 			eq.set_timer("rage_stop", 50 * 1000);
-		elseif (e.self:GetHPRatio() < 40 and e.self:GetHPRatio() >= 30) then
+		elseif e.self:GetHPRatio() < 40 and e.self:GetHPRatio() >= 30 then
 			e.self:ModifyNPCStat("min_hit", "1829");
 			e.self:ModifyNPCStat("max_hit", "5724");
 			e.self:ModifyNPCStat("attack_delay","11");
 			eq.set_timer("rage_stop", 50 * 1000);
-		elseif (e.self:GetHPRatio() < 30 and e.self:GetHPRatio() >= 20) then
+		elseif e.self:GetHPRatio() < 30 and e.self:GetHPRatio() >= 20 then
 			e.self:ModifyNPCStat("min_hit", "1883");
 			e.self:ModifyNPCStat("max_hit", "5873");
 			e.self:ModifyNPCStat("attack_delay","10");
 			eq.set_timer("rage_stop", 65 * 1000);
-		elseif (e.self:GetHPRatio() < 20 and e.self:GetHPRatio() >= 10) then
+		elseif e.self:GetHPRatio() < 20 and e.self:GetHPRatio() >= 10 then
 			e.self:ModifyNPCStat("min_hit", "1938");
 			e.self:ModifyNPCStat("max_hit", "6023");
 			e.self:ModifyNPCStat("attack_delay","9");
 			eq.set_timer("rage_stop", 65 * 1000);
-		elseif (e.self:GetHPRatio() < 10) then
+		elseif e.self:GetHPRatio() < 10 then
 			e.self:ModifyNPCStat("min_hit", "1992");
 			e.self:ModifyNPCStat("max_hit", "6172");
 			e.self:ModifyNPCStat("attack_delay","8");
 			eq.set_timer("rage_stop", 65 * 1000);
 		end
-elseif (e.timer == "check") then
-		
+	elseif e.timer == "check" then
 		local instance_id = eq.get_zone_instance_id();
 		e.self:ForeachHateList(
-		  function(ent, hate, damage, frenzy)
-			if(ent:IsClient() and ent:GetX() < 293 or ent:GetX() > 448 or ent:GetY() < 270) then
-			  local currclient=ent:CastToClient();
-				--e.self:Shout("You will not evade me " .. currclient:GetName())
-				currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-				currclient:Message(5,"Zun`Muram Shaldn Boc says, 'You cannot run from your fate, you must accept it.");
+			function(ent, hate, damage, frenzy)
+				if(ent:IsClient() and ent:GetX() < 293 or ent:GetX() > 448 or ent:GetY() < 270) then
+					local currclient=ent:CastToClient();
+					--e.self:Shout("You will not evade me " .. currclient:GetName())
+					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
+					currclient:Message(5,"Zun`Muram Shaldn Boc says, 'You cannot run from your fate, you must accept it.");
+				end
 			end
-		  end
 		);
-elseif (e.timer == "reset") then
-	eq.stop_timer("reset");
-	e.self:SetHP(e.self:GetMaxHP());
-		
-	eq.set_next_hp_event(90);
-	
-	e.self:ModifyNPCStat("min_hit", "1470");
-    	e.self:ModifyNPCStat("max_hit", "4700");
-    	e.self:ModifyNPCStat("attack_delay","19");
-		
-    	eq.get_entity_list():FindDoor(8):SetLockPick(0); --open door
-  end
+	elseif e.timer == "reset" then
+		eq.stop_timer("reset");
+		e.self:SetHP(e.self:GetMaxHP());
+		eq.set_next_hp_event(90);
+		e.self:ModifyNPCStat("min_hit", "1470");
+		e.self:ModifyNPCStat("max_hit", "4700");
+		e.self:ModifyNPCStat("attack_delay","19");
+		eq.signal(298223,2); -- Unlock Doors
+	end
 end
 
 function ZMSB_Hp(e)
-
-  if (e.hp_event == 90) then
-    eq.get_entity_list():FindDoor(8):SetLockPick(-1);
-    -- he should start checking for players on hate list outside room here
-	eq.set_timer("check", 1 * 1000);
-  end
+	if e.hp_event == 90 then
+		eq.signal(298223,1); -- Lock Doors
+		-- he should start checking for players on hate list outside room here
+		eq.set_timer("check", 1 * 1000);
+	end
 end
 
 function ZMSB_Death(e)
-  eq.signal(298223, 298018); -- NPC: zone_status
-  eq.get_entity_list():FindDoor(8):SetLockPick(0);
---should there be a check here to see if zmmd door is already open for this emote?
-eq.zone_emote(15,"The chamber is filled with the sound of grinding stone. The path leading into the final chamber has been opened and it awaits your arrival. You hear a voice that sounds oddly familiar. 'Come now, fools, enter my chamber and learn the meaning of suffering from one bred to destroy and conquer. You have beaten the best of my army, but you have yet to see true power. Step into the abyss and cower at what stares back at you.");
+	eq.signal(298223, 298018); -- NPC: zone_status
+	eq.signal(298223,2,1000); -- Unlock Doors
+	--should there be a check here to see if zmmd door is already open for this emote?
+	eq.zone_emote(15,"The chamber is filled with the sound of grinding stone. The path leading into the final chamber has been opened and it awaits your arrival. You hear a voice that sounds oddly familiar. 'Come now, fools, enter my chamber and learn the meaning of suffering from one bred to destroy and conquer. You have beaten the best of my army, but you have yet to see true power. Step into the abyss and cower at what stares back at you.");
 end
 
 function event_encounter_load(e)
-  eq.register_npc_event('zmsb', Event.spawn,          298018, ZMSB_Spawn);
-  eq.register_npc_event('zmsb', Event.combat,         298018, ZMSB_Combat);
-  eq.register_npc_event('zmsb', Event.timer,          298018, ZMSB_Timer);
-  eq.register_npc_event('zmsb', Event.hp,             298018, ZMSB_Hp);
-  eq.register_npc_event('zmsb', Event.death_complete, 298018, ZMSB_Death);
+	eq.register_npc_event('zmsb', Event.spawn,          298018, ZMSB_Spawn);
+	eq.register_npc_event('zmsb', Event.combat,         298018, ZMSB_Combat);
+	eq.register_npc_event('zmsb', Event.timer,          298018, ZMSB_Timer);
+	eq.register_npc_event('zmsb', Event.hp,             298018, ZMSB_Hp);
+	eq.register_npc_event('zmsb', Event.death_complete, 298018, ZMSB_Death);
 end

--- a/tacvi/encounters/zmsb.lua
+++ b/tacvi/encounters/zmsb.lua
@@ -23,14 +23,14 @@ function ZMSB_Timer(e)
 	if e.timer == "rage_stop" then
 		eq.stop_timer("rage_stop");
 		eq.set_timer("rage", 35 * 1000);
-		eq.zone_emote(15,"Zun`Muram Shaldn Boc looks weakened as the rage ends.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Shaldn Boc looks weakened as the rage ends.");
 		e.self:ModifyNPCStat("min_hit", "1470");
 		e.self:ModifyNPCStat("max_hit", "4700");
  		--attack delay to 1.9s
 		e.self:ModifyNPCStat("attack_delay","19");
 	elseif e.timer == "rage" then
 		eq.stop_timer("rage");
-		eq.zone_emote(15,"Zun`Muram Shaldn Boc starts to foam at the mouth as he enters a blind rage.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Shaldn Boc starts to foam at the mouth as he enters a blind rage.");
 		if e.self:GetHPRatio() >= 90 then
 			e.self:ModifyNPCStat("min_hit", "1520");
 			e.self:ModifyNPCStat("max_hit", "4850");
@@ -90,7 +90,7 @@ function ZMSB_Timer(e)
 					local currclient=ent:CastToClient();
 					--e.self:Shout("You will not evade me " .. currclient:GetName())
 					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-					currclient:Message(5,"Zun`Muram Shaldn Boc says, 'You cannot run from your fate, you must accept it.");
+					currclient:Message(MT.Magenta,"Zun`Muram Shaldn Boc says, 'You cannot run from your fate, you must accept it.");
 				end
 			end
 		);
@@ -117,7 +117,7 @@ function ZMSB_Death(e)
 	eq.signal(298223, 298018); -- NPC: zone_status
 	eq.signal(298223,2,1000); -- Unlock Doors
 	--should there be a check here to see if zmmd door is already open for this emote?
-	eq.zone_emote(15,"The chamber is filled with the sound of grinding stone. The path leading into the final chamber has been opened and it awaits your arrival. You hear a voice that sounds oddly familiar. 'Come now, fools, enter my chamber and learn the meaning of suffering from one bred to destroy and conquer. You have beaten the best of my army, but you have yet to see true power. Step into the abyss and cower at what stares back at you.");
+	eq.zone_emote(MT.Yellow,"The chamber is filled with the sound of grinding stone. The path leading into the final chamber has been opened and it awaits your arrival. You hear a voice that sounds oddly familiar. 'Come now, fools, enter my chamber and learn the meaning of suffering from one bred to destroy and conquer. You have beaten the best of my army, but you have yet to see true power. Step into the abyss and cower at what stares back at you.");
 end
 
 function event_encounter_load(e)

--- a/tacvi/encounters/zmyv.lua
+++ b/tacvi/encounters/zmyv.lua
@@ -46,7 +46,7 @@ function ZMYV_Timer(e)
 					local currclient=ent:CastToClient();
 					--e.self:Shout("You will not evade me " .. currclient:GetName())
 					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-					currclient:Message(5,"Zun`Muram Yihst Vor says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+					currclient:Message(MT.Magenta,"Zun`Muram Yihst Vor says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
 				end
 			end
 		);
@@ -58,21 +58,21 @@ function ZMYV_Hp(e)
 		eq.signal(298223,1); -- Lock Doors
 		eq.set_timer("check", 1 * 1000); -- set scorpion timer
 		eq.set_next_hp_event(75);
-		eq.zone_emote(15,"Zun`Muram Yihst Vor says, 'Is this is the best you can do? Come now, show me your true strength and I will show you mine.' ");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor says, 'Is this is the best you can do? Come now, show me your true strength and I will show you mine.' ");
 		e.self:ModifyNPCStat("min_hit", "1899");
 		e.self:ModifyNPCStat("max_hit", "5176");
 	elseif e.hp_event == 75 then
 		eq.set_next_hp_event(50);
-		eq.zone_emote(15,"Zun`Muram Yihst Vor says, 'To think I was actually worried you might be worthy foes.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor says, 'To think I was actually worried you might be worthy foes.");
 		e.self:ModifyNPCStat("min_hit", "2124");
 		e.self:ModifyNPCStat("max_hit", "5401");
 	elseif e.hp_event == 50 then
 		eq.set_next_hp_event(20);
-		eq.zone_emote(15,"Zun`Muram Yihst Vor says, 'Ahh, sweet pain. It is such an intoxicating feeling. I thank you for the pleasure. Now let me return the favor.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor says, 'Ahh, sweet pain. It is such an intoxicating feeling. I thank you for the pleasure. Now let me return the favor.");
 		e.self:ModifyNPCStat("min_hit", "2254");
 		e.self:ModifyNPCStat("max_hit", "5591");
 	elseif e.hp_event == 20 then
-		eq.zone_emote(15,"Zun`Muram Yihst Vor's body bulges with strength as he enters a blind rage.");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor's body bulges with strength as he enters a blind rage.");
 		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
 		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 50); -- 50% Mitigation
 		e.self:SetSpecialAbility(SpecialAbility.rampage, 0);

--- a/tacvi/encounters/zmyv.lua
+++ b/tacvi/encounters/zmyv.lua
@@ -1,100 +1,96 @@
-
 function ZMYV_Spawn(e)
-  eq.get_entity_list():FindDoor(21):SetLockPick(0);
-  eq.set_next_hp_event(90);
-e.self:ModSkillDmgTaken(1, 5); -- 1h slashing
-e.self:ModSkillDmgTaken(3, 5); -- 2h slashing
+	eq.signal(298223,2); -- Unlock Doors
+	eq.set_next_hp_event(90);
+	e.self:ModSkillDmgTaken(1, 5); -- 1h slashing
+	e.self:ModSkillDmgTaken(3, 5); -- 2h slashing
 end
 
 function ZMYV_Combat(e)
-  if (e.joined == true) then
-    e.self:Say("The weak willed and the idle will serve my cause.");
-    --eq.set_timer("allure", 90 * 1000);
-  else
-    eq.set_timer("wipecheck", 1 * 1000);
-    eq.stop_timer("check");
-	--eq.stop_timer("allure");
-  end
+	if e.joined then
+		e.self:Say("The weak willed and the idle will serve my cause.");
+		eq.set_timer("allure", 90 * 1000);
+	else
+		eq.set_timer("wipecheck", 1 * 1000);
+		eq.stop_timer("check");
+		eq.stop_timer("allure");
+	end
 end
 
 function ZMYV_Timer(e)
-  if (e.timer == "wipecheck") then
-    local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 8000);
-    if (client:IsClient() == false) then
-      -- Wipe Mechanics
-      eq.get_entity_list():FindDoor(21):SetLockPick(0);
-      eq.spawn2(298023, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()); -- NPC: Zun`Muram_Yihst_Vor
-      eq.depop();
-    end
-    
-elseif e.timer == "allure" then 
-		local total_cast = 0;
-		while total_cast <= 6 do -- cast on 6 players - No pets
-			if blah then
-				local target = e.self:GetHateRandom();
-				if target:IsClient() then
-					total_cast = total_cast + 1;
-					e.self:CastedSpellFinished(4441, target); -- Spell: Allure of Hatred
-				end
+	if e.timer == "wipecheck" then
+		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 8000);
+		if not client:IsClient() then
+			-- Wipe Mechanics
+			eq.signal(298223,2); -- Unlock Doors
+			eq.spawn2(298023, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()); -- NPC: Zun`Muram_Yihst_Vor
+			eq.stop_timer("memblur");
+			eq.depop();
+		end
+	elseif e.timer == "allure" then 
+		for i=1,6 do
+			local target = e.self:GetHateRandom();
+			if target:IsPet() then
+				target = target:GetOwner();
+			end
+
+			if target.valid and not target:FindBuff(4441) then
+				e.self:SpellFinished(4441, target); -- Spell: Allure of Hatred
 			end
 		end
 		e.self:WipeHateList();
-	elseif (e.timer == "check") then
+	elseif e.timer == "check" then
 		local instance_id = eq.get_zone_instance_id();
 		e.self:ForeachHateList(
-		  function(ent, hate, damage, frenzy)
-			if(ent:IsClient() and ent:GetX() < 295 or ent:GetX() > 447 or ent:GetY() < -560 or ent:GetY() > -418) then
-			  local currclient=ent:CastToClient();
-				--e.self:Shout("You will not evade me " .. currclient:GetName())
-				currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-				currclient:Message(5,"Zun`Muram Yihst Vor says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+			function(ent, hate, damage, frenzy)
+				if(ent:IsClient() and ent:GetX() < 295 or ent:GetX() > 447 or ent:GetY() < -560 or ent:GetY() > -418) then
+					local currclient=ent:CastToClient();
+					--e.self:Shout("You will not evade me " .. currclient:GetName())
+					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
+					currclient:Message(5,"Zun`Muram Yihst Vor says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+				end
 			end
-		  end
 		);
 	end
 end
 
 function ZMYV_Hp(e)
-  if (e.hp_event == 90) then
-    eq.get_entity_list():FindDoor(21):SetLockPick(-1);
-    eq.set_timer("check", 1 * 1000); -- set scorpion timer
-    eq.set_next_hp_event(75);
-    eq.zone_emote(15,"Zun`Muram Yihst Vor says, 'Is this is the best you can do? Come now, show me your true strength and I will show you mine.");
-    e.self:ModifyNPCStat("min_hit", tostring(1899));
-    e.self:ModifyNPCStat("max_hit", tostring(5176));
-  elseif (e.hp_event == 75) then
-    eq.set_next_hp_event(50);
-    eq.zone_emote(15,"Zun`Muram Yihst Vor says, 'To think I was actually worried you might be worthy foes.");
-    e.self:ModifyNPCStat("min_hit", tostring(2124));
-    e.self:ModifyNPCStat("max_hit", tostring(5401));
-  elseif (e.hp_event == 50) then
-    eq.set_next_hp_event(20);
-    eq.zone_emote(15,"Zun`Muram Yihst Vor says, 'Ahh, sweet pain. It is such an intoxicating feeling. I thank you for the pleasure. Now let me return the favor.");
-    e.self:ModifyNPCStat("min_hit", tostring(2254));
-    e.self:ModifyNPCStat("max_hit", tostring(5591));
-  elseif (e.hp_event == 20) then
-    eq.zone_emote(15,"Zun`Muram Yihst Vor's body bulges with strength as he enters a blind rage.");
+	if e.hp_event == 90 then
+		eq.signal(298223,1); -- Lock Doors
+		eq.set_timer("check", 1 * 1000); -- set scorpion timer
+		eq.set_next_hp_event(75);
+		eq.zone_emote(15,"Zun`Muram Yihst Vor says, 'Is this is the best you can do? Come now, show me your true strength and I will show you mine.' ");
+		e.self:ModifyNPCStat("min_hit", "1899");
+		e.self:ModifyNPCStat("max_hit", "5176");
+	elseif e.hp_event == 75 then
+		eq.set_next_hp_event(50);
+		eq.zone_emote(15,"Zun`Muram Yihst Vor says, 'To think I was actually worried you might be worthy foes.");
+		e.self:ModifyNPCStat("min_hit", "2124");
+		e.self:ModifyNPCStat("max_hit", "5401");
+	elseif e.hp_event == 50 then
+		eq.set_next_hp_event(20);
+		eq.zone_emote(15,"Zun`Muram Yihst Vor says, 'Ahh, sweet pain. It is such an intoxicating feeling. I thank you for the pleasure. Now let me return the favor.");
+		e.self:ModifyNPCStat("min_hit", "2254");
+		e.self:ModifyNPCStat("max_hit", "5591");
+	elseif e.hp_event == 20 then
+		eq.zone_emote(15,"Zun`Muram Yihst Vor's body bulges with strength as he enters a blind rage.");
 		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
 		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 50); -- 50% Mitigation
 		e.self:SetSpecialAbility(SpecialAbility.rampage, 0);
 		e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
-    e.self:ModifyNPCStat("min_hit", tostring(2573));
-    e.self:ModifyNPCStat("max_hit", tostring(5850));
-  end
+		e.self:ModifyNPCStat("min_hit", "2573");
+		e.self:ModifyNPCStat("max_hit", "5850");
+	end
 end
 
 function ZMYV_Death(e)
-  eq.signal(298223,298023); -- NPC: zone_status
-  eq.get_entity_list():FindDoor(21):SetLockPick(0);
+	eq.signal(298223,298023); -- NPC: zone_status
+	eq.signal(298223,2,1000); -- Unlock Doors
 end
 
 function event_encounter_load(e)
-  eq.register_npc_event('zmyv', Event.spawn,          298023, ZMYV_Spawn); 
-  eq.register_npc_event('zmyv', Event.combat,         298023, ZMYV_Combat); 
-  eq.register_npc_event('zmyv', Event.timer,          298023, ZMYV_Timer); 
-  eq.register_npc_event('zmyv', Event.hp,             298023, ZMYV_Hp); 
-  eq.register_npc_event('zmyv', Event.death_complete, 298023, ZMYV_Death); 
-end
-
-function event_encounter_unload(e)
+	eq.register_npc_event('zmyv', Event.spawn,          298023, ZMYV_Spawn); 
+	eq.register_npc_event('zmyv', Event.combat,         298023, ZMYV_Combat); 
+	eq.register_npc_event('zmyv', Event.timer,          298023, ZMYV_Timer); 
+	eq.register_npc_event('zmyv', Event.hp,             298023, ZMYV_Hp); 
+	eq.register_npc_event('zmyv', Event.death_complete, 298023, ZMYV_Death); 
 end

--- a/tacvi/player.lua
+++ b/tacvi/player.lua
@@ -38,8 +38,8 @@ function event_click_door(e)
 	end
 	
 	if eq.get_entity_list():FindDoor(door_id):GetLockPick() == 0 then
-		e.self:Message(6, "As the massive door gives way, you are overwhelmed by the smell of decaying flesh.");
+		e.self:Message(MT.Gray, "As the massive door gives way, you are overwhelmed by the smell of decaying flesh.");
 	else
-		e.self:Message(6, "A barrier of energy seals the door before you.");
+		e.self:Message(MT.Gray, "A barrier of energy seals the door before you.");
 	end
 end

--- a/tacvi/player.lua
+++ b/tacvi/player.lua
@@ -1,53 +1,45 @@
-local Tacvi_Doors = {}
-local Tacvi_Lockouts = {}
-
-function setup()
-  Tacvi_Doors = {
-    [3] = 298039,
-    [4] = 298039,
-    [6] = 298201,
-    [7] = 298201,
-    [17] = 298032,
-    [22] = 298032,
-    [9] = 298018,
-    [12] = 298020,
-    [20] = 298023,
-    [15] = 298029
-  }
-end
+local Tacvi_Doors = {
+	[3] = 298039,
+	[4] = 298039,
+	[6] = 298201,
+	[7] = 298201,
+	[17] = 298032,
+	[22] = 298032,
+	[9] = 298018,
+	[12] = 298020,
+	[20] = 298023,
+	[15] = 298029
+}
 
 function event_click_door(e)
-  setup();
-  local door_id = e.door:GetDoorID();
+	local door_id = e.door:GetDoorID();
 
-  if ( Tacvi_Doors[ door_id ] ) then
-    -- If the Door Clicked is tied to a mob.
-    if (eq.get_entity_list():IsMobSpawnedByNpcTypeID( Tacvi_Doors[ door_id ] ) ) then 
-      eq.get_entity_list():FindDoor(door_id):SetLockPick(-1);
-    else
-      eq.get_entity_list():FindDoor(door_id):SetLockPick(0);
-    end
-  end
+	if Tacvi_Doors[door_id] then
+		-- If the Door Clicked is tied to a mob.
+		if eq.get_entity_list():IsMobSpawnedByNpcTypeID(Tacvi_Doors[ door_id ]) then 
+			eq.get_entity_list():FindDoor(door_id):SetLockPick(-1);
+		else
+			eq.get_entity_list():FindDoor(door_id):SetLockPick(0);
+		end
+	end
 
-  -- 
-  -- To Open Door 19 or 14; both ZMYV and ZMKP need to be dead
-  if ( (door_id == 19 or door_id == 14) and (eq.get_entity_list():IsMobSpawnedByNpcTypeID(298023) or eq.get_entity_list():IsMobSpawnedByNpcTypeID(298029)) ) then 
-    eq.get_entity_list():FindDoor(door_id):SetLockPick(-1);
-  elseif (door_id == 19 or door_id == 14) then
-    eq.get_entity_list():FindDoor(door_id):SetLockPick(0);
-  end
+	-- To Open Door 19 or 14; both ZMYV and ZMKP need to be dead
+	if (door_id == 19 or door_id == 14) and (eq.get_entity_list():IsMobSpawnedByNpcTypeID(298023) or eq.get_entity_list():IsMobSpawnedByNpcTypeID(298029)) then 
+		eq.get_entity_list():FindDoor(door_id):SetLockPick(-1);
+	elseif door_id == 19 or door_id == 14 then
+		eq.get_entity_list():FindDoor(door_id):SetLockPick(0);
+	end
 
-  --
-  -- To Open door 10 or 11; both ZMSB and ZMMD need to be dead
-  if ( (door_id == 10 or door_id == 11) and (eq.get_entity_list():IsMobSpawnedByNpcTypeID(298020) or eq.get_entity_list():IsMobSpawnedByNpcTypeID(29818)) ) then 
-    eq.get_entity_list():FindDoor(door_id):SetLockPick(-1);
-  elseif (door_id == 10 or door_id == 11) then
-    eq.get_entity_list():FindDoor(door_id):SetLockPick(0);
-  end
-  
-  if ( eq.get_entity_list():FindDoor(door_id):GetLockPick() == 0 ) then
-    e.self:Message(6, "As the massive door gives way, you are overwhelmed by the smell of decaying flesh.");
-  else
-    e.self:Message(6, "A barrier of energy seals the door before you.");
-  end
+	-- To Open door 10 or 11; both ZMSB and ZMMD need to be dead
+	if (door_id == 10 or door_id == 11) and (eq.get_entity_list():IsMobSpawnedByNpcTypeID(298020) or eq.get_entity_list():IsMobSpawnedByNpcTypeID(29818)) then 
+		eq.get_entity_list():FindDoor(door_id):SetLockPick(-1);
+	elseif door_id == 10 or door_id == 11 then
+		eq.get_entity_list():FindDoor(door_id):SetLockPick(0);
+	end
+	
+	if eq.get_entity_list():FindDoor(door_id):GetLockPick() == 0 then
+		e.self:Message(6, "As the massive door gives way, you are overwhelmed by the smell of decaying flesh.");
+	else
+		e.self:Message(6, "A barrier of energy seals the door before you.");
+	end
 end

--- a/tacvi/zone_status.lua
+++ b/tacvi/zone_status.lua
@@ -3,17 +3,6 @@
 -- Control the Player Lockouts
 -- 298223
 --
--- Lockouts: 
--- Add - Bit - Mob
--- 1 -     1 - PXK Pixtt Xxeric Kex
--- 2 -     2 - PKK Pixtt Kretv Krakxt
--- 3 -     4 - PRT Pixtt rei Tavas
--- 4 -     8 - ZMKP Zun`Muram Kvxe Pirik
--- 5 -    16 - ZMSB Zun`Muram Shaldn Boc
--- 6 -    32 - ZMMD Zun`Muram Mordl Delt
--- 7 -    64 - ZMYV Zun`Muram Yihst Vor
--- 8 -   128 - TMCV Tunat`Muram Cuu Vauax
---
 -- Mob IDs:
 -- PXK  298039
 -- PKK  298201
@@ -29,173 +18,237 @@
 -- 298016 an_elite_mastruq_crusher
 -- 298021 an_elite_mastruq_destroyer
 --
+-- Tacvi, Seat of the Slaver 
+--
 --]]
 --
-local lockout_bit;
+
 local instance_id = 0;
-local qglobals = {};
 local charid_list;
-local current_bit = 0;
 local entity_list;
-local instance_requests = require("instance_requests");
 local Tacvi_Lockouts = {}
 
-function setup_lockouts()
-  Tacvi_Lockouts = {
-    [298039] = {'Tacvi_PXK', 1, Spawn_PXK},
-    [298201] = {'Tacvi_PKK', 2, Spawn_PKK},
-    [298032] = {'Tacvi_PRT', 4, Spawn_PRT},
-    [298029] = {'Tacvi_ZMKP', 8, Spawn_ZMKP},
-    [298018] = {'Tacvi_ZMSB', 16, Spawn_ZMSB},
-    [298020] = {'Tacvi_ZMMD', 32, Spawn_ZMMD},
-    [298023] = {'Tacvi_ZMYV', 64, Spawn_ZMYV},
-    [298055] = {'Tacvi_TMCV', 128, Spawn_TMCV}
-  }
+-- Events
+local PXK_EVENT		= 'Pixtt Xxeric Kex'
+local PKK_EVENT		= 'Pixtt Kretv Krakxt'
+local PRT_EVENT		= 'Pixtt Riel Tavas'
+local ZMKP_EVENT	= 'Zun`Muram Kvxe Pirik'
+local ZMSB_EVENT	= 'Zun`Muram Shaldn Boc'
+local ZMMD_EVENT	= 'Zun`Muram Mordl Delt'
+local ZMYV_EVENT	= 'Zun`Muram Yihst Vor'
+local TMCV_EVENT	= 'Tunat`Muram Cuu Vauax'
+
+
+function setup_event() -- 4.5 Days
+	Tacvi_Lockouts = {
+		[298039] = {PXK_EVENT,	eq.seconds('108h'), Spawn_PXK},
+		[298201] = {PKK_EVENT,	eq.seconds('108h'), Spawn_PKK},
+		[298032] = {PRT_EVENT,	eq.seconds('108h'), Spawn_PRT},
+		[298029] = {ZMKP_EVENT,	eq.seconds('108h'), Spawn_ZMKP},
+		[298018] = {ZMSB_EVENT,	eq.seconds('108h'), Spawn_ZMSB},
+		[298020] = {ZMMD_EVENT,	eq.seconds('108h'), Spawn_ZMMD},
+		[298023] = {ZMYV_EVENT,	eq.seconds('108h'), Spawn_ZMYV},
+		[298055] = {TMCV_EVENT,	eq.seconds('108h'), Spawn_TMCV}
+	}
 end
 
 function event_spawn(e)
-  qglobals = eq.get_qglobals();
-  instance_id = eq.get_zone_instance_id();
-  charid_list = eq.get_characters_in_instance(instance_id);
-  entity_list = eq.get_entity_list();
-  lockout_bit = tonumber(qglobals[instance_id .. "_tacvi_bit"]);
-  if (lockout_bit == nil) then lockout_bit = 0 end
-  setup_lockouts();
+	instance_id = eq.get_zone_instance_id();
+	charid_list = eq.get_characters_in_instance(instance_id);
+	entity_list = eq.get_entity_list();
+	local zone_id = eq.get_zone_id();
+	local expedition = eq.get_expedition_by_zone_instance(zone_id,instance_id);
 
-  -- Door at zone in; Talking to Sensnil will unlock
-  Door_Lock(18);
+	if expedition.valid then
+		setup_event();
+	end
 
-  -- Doors to TMCV
-  Door_Lock(10);
-  Door_Lock(11);
-  Door_Lock(14);
-  Door_Lock(19);
+	-- Door at zone in; Talking to Sensnil will unlock
+	Door_Lock(18);
 
-  for k,v in pairs(Tacvi_Lockouts) do
-    if (bit.band(lockout_bit, v[2]) == 0 and v[3] ~= nil ) then
-      v[3]();
-    end
-  end
+	-- Doors to TMCV
+	Door_Lock(10);
+	Door_Lock(11);
+	Door_Lock(14);
+	Door_Lock(19);
 
+	for k,v in pairs(Tacvi_Lockouts) do
+		if v[3] and not expedition:HasLockout(v[1]) then
+			v[3]() -- boss spawning function
+		end
+	end
 end
 
 function Spawn_PXK()
-  eq.spawn2(298039, 0, 0, 151.00, -162.00, -0.375, 386); -- NPC: Pixtt_Xxeric_Kex
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 37.0, -165.0, -2.75, 392); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  -- Zajee's remains
-  eq.spawn2(298038, 0, 0, 12, -106, -6.03, 264):SetAppearance(3); -- NPC: #Zajeer`s_remains
+	eq.spawn2(298039, 0, 0, 151.00, -162.00, -0.375, 386); -- NPC: Pixtt_Xxeric_Kex
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 37.0, -165.0, -2.75, 392); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	-- Zajee's remains
+	eq.spawn2(298038, 0, 0, 12, -106, -6.03, 264):SetAppearance(3); -- NPC: #Zajeer`s_remains
 end
 
 function Spawn_PKK()
-  eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378); -- NPC: Pixtt_Kretv_Krakxt
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 76.0, 246.0, -2.75, 388); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  -- Frizznik's remains
-  eq.spawn2(298036, 0, 0, 49, 251, -6.03, 40):SetAppearance(3); -- NPC: #Frizznik`s_Remains
+	eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378); -- NPC: Pixtt_Kretv_Krakxt
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 76.0, 246.0, -2.75, 388); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	-- Frizznik's remains
+	eq.spawn2(298036, 0, 0, 49, 251, -6.03, 40):SetAppearance(3); -- NPC: #Frizznik`s_Remains
 end
 
 function Spawn_PRT()
-  eq.spawn2(298032, 0, 0, 202.0, -586.0, -4.125, 380); -- NPC: Pixtt_Riel_Tavas
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 83.0, -586.0, -2.75, 378); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  -- Absor's Remains
-  eq.spawn2(298037, 0, 0, 66, -448, -6.03, 208):SetAppearance(3); -- NPC: #Absor`s_Remains
+	eq.spawn2(298032, 0, 0, 202.0, -586.0, -4.125, 380); -- NPC: Pixtt_Riel_Tavas
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 83.0, -586.0, -2.75, 378); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	-- Absor's Remains
+	eq.spawn2(298037, 0, 0, 66, -448, -6.03, 208):SetAppearance(3); -- NPC: #Absor`s_Remains
 end
 
 function Spawn_ZMKP()
-  eq.spawn2(298029, 0, 0, 373.0, -686.0, -0.375, 352); -- NPC: Zun`Muram_Kvxe_Pirik
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 276.0, -685.0, -2.75, 366); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  -- Wijdan's Remains
-  eq.spawn2(298030, 0, 0, 211, -683, -6.03, 496):SetAppearance(3); -- NPC: #Wijdan`s_Remains
+	eq.spawn2(298029, 0, 0, 373.0, -686.0, -0.375, 352); -- NPC: Zun`Muram_Kvxe_Pirik
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 276.0, -685.0, -2.75, 366); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	-- Wijdan's Remains
+	eq.spawn2(298030, 0, 0, 211, -683, -6.03, 496):SetAppearance(3); -- NPC: #Wijdan`s_Remains
 end
 
 function Spawn_ZMSB()
-  eq.spawn2(298018, 0, 0, 366.0, 342.0, -0.375, 360); -- NPC: Zun`Muram_Shaldn_Boc
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 274.0, 345.0, -2.75, 364); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  -- Xenaida's remains
-  eq.spawn2(298033, 0, 0, 230, 335, -6.03, 296):SetAppearance(3); -- NPC: #Xenaida`s_Remains
+	eq.spawn2(298018, 0, 0, 366.0, 342.0, -0.375, 360); -- NPC: Zun`Muram_Shaldn_Boc
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 274.0, 345.0, -2.75, 364); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	-- Xenaida's remains
+	eq.spawn2(298033, 0, 0, 230, 335, -6.03, 296):SetAppearance(3); -- NPC: #Xenaida`s_Remains
 end
 
 function Spawn_ZMMD()
-  eq.spawn2(298020, 0, 0, 369.0, 144.0, -0.375, 352); -- NPC: Zun`Muram_Mordl_Delt
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 270.0, 146.0, -2.75, 370); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  -- Rytan's remains
-  eq.spawn2(298034, 0, 0, 229, 149, -6.03, 504):SetAppearance(3); -- NPC: #Rytan`s_Remains
+	eq.spawn2(298020, 0, 0, 369.0, 144.0, -0.375, 352); -- NPC: Zun`Muram_Mordl_Delt
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 270.0, 146.0, -2.75, 370); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	-- Rytan's remains
+	eq.spawn2(298034, 0, 0, 229, 149, -6.03, 504):SetAppearance(3); -- NPC: #Rytan`s_Remains
 end
 
 function Spawn_ZMYV()
-  eq.spawn2(298023, 0, 0, 366.0, -488.0, -0.375, 352); -- NPC: Zun`Muram_Yihst_Vor
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 272.0, -487.0, -2.75, 354); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  -- Prathun's Remains
-  eq.spawn2(298022, 0, 0, 197, -493, -6.77, 121.2):SetAppearance(3); -- NPC: #Prathun`s_Remains
+	eq.spawn2(298023, 0, 0, 366.0, -488.0, -0.375, 352); -- NPC: Zun`Muram_Yihst_Vor
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 272.0, -487.0, -2.75, 354); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	-- Prathun's Remains
+	eq.spawn2(298022, 0, 0, 197, -493, -6.77, 121.2):SetAppearance(3); -- NPC: #Prathun`s_Remains
 end
 
 function Spawn_TMCV()
-  -- TMCV 462, -171, 32, 8
-  -- Living Phylactery
-  --  454, -242, 25.5, 32
-  --  431, -100, 25.5, 56
-  --  487, -100, 25.5, 76
-  --  476, -242, 25.5, 92
-  --  498, -193, 25.5, 228
-  -- Door Guards
-  --  602 16 21.23 249.9
-  --  535 72 23.48 236
-  --  601 -362 21.23 134.5
-  --  538 -416 15.23 129.1
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 602.0, 16.0, 25.125, 4); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 535.0, 72.0, 21.125, 14); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 601.0, -362.0, 25.125, 258); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-  eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 538.0, -416.0, 19.125, 258); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	-- TMCV 462, -171, 32, 8
+	-- Living Phylactery
+	--  454, -242, 25.5, 32
+	--  431, -100, 25.5, 56
+	--  487, -100, 25.5, 76
+	--  476, -242, 25.5, 92
+	--  498, -193, 25.5, 228
+	-- Door Guards
+	--  602 16 21.23 249.9
+	--  535 72 23.48 236
+	--  601 -362 21.23 134.5
+	--  538 -416 15.23 129.1
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 602.0, 16.0, 25.125, 4); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 535.0, 72.0, 21.125, 14); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 601.0, -362.0, 25.125, 258); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 538.0, -416.0, 19.125, 258); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
 
-  eq.spawn2(298014, 0, 0, 462, -171, 32, 128.2); -- NPC: #Tunat`Muram_Cuu_Vauax
+	eq.spawn2(298014, 0, 0, 462, -171, 32, 128.2); -- NPC: #Tunat`Muram_Cuu_Vauax
 
-  -- Rashere's remains
-  eq.spawn2(298031, 0, 0, 506, 147, -6.03, 480):SetAppearance(3); -- NPC: #Rashere`s_Remains
-  -- Kaikachi`s remains
-  eq.spawn2(298017, 0, 0, 592, 313, -6.03, 440):SetAppearance(3); -- NPC: #Kaikachi`s_Remains
-  -- Lyndroh's remains
-  eq.spawn2(298010, 0, 0, 320, -144, 21.85, 96):SetAppearance(3); -- NPC: #Lyndroh`s_Remains
-  -- Silius's remains
-  eq.spawn2(298009, 0, 0, 322, -199, 21.85, 168):SetAppearance(3); -- NPC: #Silius`_Remains
-  -- Maddoc's remains
-  eq.spawn2(298011, 0, 0, 483, -171, 25.85, 496):SetAppearance(3); -- NPC: #Maddoc`s_Remains
-  -- Vahlara's remains
-  eq.spawn2(298024, 0, 0, 600, -588, -6.03, 0.0):SetAppearance(3); -- NPC: #Vahlara`s_Remains
-  -- Valtron's remains
-  eq.spawn2(298019, 0, 0, 494, -494, -6.125, 312):SetAppearance(3); -- NPC: #Valtron`s_Remains
+	-- Rashere's remains
+	eq.spawn2(298031, 0, 0, 506, 147, -6.03, 480):SetAppearance(3); -- NPC: #Rashere`s_Remains
+	-- Kaikachi`s remains
+	eq.spawn2(298017, 0, 0, 592, 313, -6.03, 440):SetAppearance(3); -- NPC: #Kaikachi`s_Remains
+	-- Lyndroh's remains
+	eq.spawn2(298010, 0, 0, 320, -144, 21.85, 96):SetAppearance(3); -- NPC: #Lyndroh`s_Remains
+	-- Silius's remains
+	eq.spawn2(298009, 0, 0, 322, -199, 21.85, 168):SetAppearance(3); -- NPC: #Silius`_Remains
+	-- Maddoc's remains
+	eq.spawn2(298011, 0, 0, 483, -171, 25.85, 496):SetAppearance(3); -- NPC: #Maddoc`s_Remains
+	-- Vahlara's remains
+	eq.spawn2(298024, 0, 0, 600, -588, -6.03, 0.0):SetAppearance(3); -- NPC: #Vahlara`s_Remains
+	-- Valtron's remains
+	eq.spawn2(298019, 0, 0, 494, -494, -6.125, 312):SetAppearance(3); -- NPC: #Valtron`s_Remains
 
 end
 
 function Door_Lock(door_id)
-  local door = 0;
-  door = entity_list:FindDoor(door_id);
-  if (door ~= nil) then
-    door:SetLockPick(-1);
-  end
+	local door = 0;
+	door = entity_list:FindDoor(door_id);
+	if (door ~= nil) then
+		door:SetLockPick(-1);
+	end
 end
 
 function Door_Unlock(door_id)
-  local door = 0;
-  door = entity_list:FindDoor(door_id);
-  if (door ~= nil) then
-    door:SetLockPick(0);
-  end
-end
-
-function AddLockout(lockout)
-  local lockout_name = lockout[1]; 
-  local lockout_bit = lockout[2];
-
-  current_bit = tonumber(qglobals[instance_id.."_tacvi_bit"]); 
-  eq.set_global(instance_id.."_tacvi_bit",tostring(bit.bor(current_bit,lockout_bit)),7,"H6"); 
-
-  for k,v in pairs(charid_list) do                                                                              
-    eq.target_global(lockout_name, tostring(instance_requests.GetLockoutEndTimeForHours(108)), "H108", 0,v, 0);
-  end                                                                                                           
+	local door = 0;
+	door = entity_list:FindDoor(door_id);
+	if (door ~= nil) then
+		door:SetLockPick(0);
+	end
 end
 
 function event_signal(e)
-  if ( Tacvi_Lockouts[e.signal] ~= nil ) then
-    AddLockout( Tacvi_Lockouts[e.signal] );
-  end
+	if e.signal == 1 then -- Lock all doors
+		for i=2,23 do
+			eq.get_entity_list():FindDoor(i):SetLockPick(-1);
+		end
+	elseif e.signal == 2 then -- Unlock all cleared doors
+		local expedition = eq.get_expedition()
+		if expedition.valid then
+			-- Unlock main door and PXK door always
+			eq.get_entity_list():FindDoor(18):SetLockPick(0); -- Main Entrance
+			eq.get_entity_list():FindDoor(2):SetLockPick(0); -- PXK Entrance
+
+			if expedition:HasLockout(PXK_EVENT) then -- unlock PXK North/South and PKK/PRT Entrance
+				eq.get_entity_list():FindDoor(3):SetLockPick(0); -- PKK South Exit
+				eq.get_entity_list():FindDoor(4):SetLockPick(0); -- PXK North Exit
+				eq.get_entity_list():FindDoor(5):SetLockPick(0); -- PKK Entrance
+				eq.get_entity_list():FindDoor(23):SetLockPick(0); -- PRT Entrance
+			end
+
+			if expedition:HasLockout(PKK_EVENT) then -- unlock PKK North/South and ZMSB/ZMMD Entrance
+				eq.get_entity_list():FindDoor(6):SetLockPick(0); -- PKK South Exit
+				eq.get_entity_list():FindDoor(7):SetLockPick(0); -- PKK North Exit
+				eq.get_entity_list():FindDoor(8):SetLockPick(0); -- ZMSB Entrance
+				eq.get_entity_list():FindDoor(13):SetLockPick(0); -- ZMMD Entrance
+			end
+
+			if expedition:HasLockout(ZMSB_EVENT) then -- unlock ZMSB Exit and ZMSB Tunat Entrance
+				eq.get_entity_list():FindDoor(9):SetLockPick(0); -- ZMSB Exit
+				eq.get_entity_list():FindDoor(10):SetLockPick(0); -- ZMSB Tunat
+			end
+
+			if expedition:HasLockout(ZMMD_EVENT) then -- unlock ZMMD Exit and ZMMD Tunat Entrance
+				eq.get_entity_list():FindDoor(12):SetLockPick(0); -- ZMMD Exit
+				eq.get_entity_list():FindDoor(11):SetLockPick(0); -- ZMMD Tunat
+			end
+
+			if expedition:HasLockout(PRT_EVENT) then -- unlock PRT North/South and ZMYV/ZMKP Entrance
+				eq.get_entity_list():FindDoor(17):SetLockPick(0); -- PRT South Exit
+				eq.get_entity_list():FindDoor(22):SetLockPick(0); -- PRT North Exit
+				eq.get_entity_list():FindDoor(21):SetLockPick(0); -- ZMYV Entrance
+				eq.get_entity_list():FindDoor(16):SetLockPick(0); -- ZMKP Entrance
+			end
+
+			if expedition:HasLockout(ZMYV_EVENT) then -- unlock ZMYV Exit and ZMYV Tunat Entrance
+				eq.get_entity_list():FindDoor(20):SetLockPick(0); -- ZMYV Exit
+				eq.get_entity_list():FindDoor(19):SetLockPick(0); -- ZMYV Tunat
+			end
+
+			if expedition:HasLockout(ZMKP_EVENT) then -- unlock ZMKP Exit and ZMKP Tunat Entrance
+				eq.get_entity_list():FindDoor(15):SetLockPick(0); -- ZMKP Exit
+				eq.get_entity_list():FindDoor(14):SetLockPick(0); -- ZMKP Tunat
+			end
+		end
+	elseif ( Tacvi_Lockouts[e.signal] ~= nil ) then
+		AddLockout( Tacvi_Lockouts[e.signal] );
+	end
 end
 
+function AddLockout(lockout)
+	local lockout_name = lockout[1];
+	local lockout_duration = lockout[2];
+
+	local expedition = eq.get_expedition()
+	if expedition.valid then
+		-- this should add the lockout to:
+		-- 1) the expedition internally, so anyone that gets added after and zones in will receive it
+		-- 2) all current members of the expedition, even if they're in another zone
+		-- 3) all clients currently inside the dz instance in case members were removed but haven't been teleported out yet
+		expedition:AddLockout(lockout_name, lockout_duration)
+	end
+end

--- a/txevu/Hamari_Nedu.lua
+++ b/txevu/Hamari_Nedu.lua
@@ -1,51 +1,40 @@
+local tacvi = "Tacvi, Seat of the Slaver"
+local tacvi_raid = {
+	expedition = { name="Tacvi, Seat of the Slaver", min_players=18, max_players=54 },
+	instance   = { zone="tacvi", version=0, duration=eq.seconds("6h") },
+	compass    = { zone="txevu", x=-133.21, y=-210.36, z=-421.04 },
+	safereturn = { zone="txevu", x=-325, y=0, z=-422.12, h=128 },
+	zonein     = { x=4, y=9, z=-6.87, h=376 }
+}
+
 function event_say(e) 
-	local instance_requests = require("instance_requests");
-	local lockout_globals = {
-      { "Tacvi_PXK", "Tacvi: Pixtt Xxeric Kex" },
-      { "Tacvi_PKK", "Tacvi: Pixtt Kretv Krakxt" },
-      { "Tacvi_PRT", "Tacvi: Pixtt Riel Tavas" },
-      { "Tacvi_ZMKP", "Tacvi: Zun`Muram Kvxe Pirik" },
-      { "Tacvi_ZMSB", "Tacvi: Zun`Muram Shaldn Boc" },
-      { "Tacvi_ZMMD", "Tacvi: Zun`Muram Mordl Delt" },
-      { "Tacvi_ZMYV", "Tacvi: Zun`Muram Yihst Vor" },   
-      { "Tacvi_TMCV", "Tacvi: Tunat`Muram Cuu Vauax" }
-		}
-
-  if (e.message:findi("lockouts")) then
-		instance_requests.DisplayLockouts(e.other, e.other, lockout_globals)
-  elseif (e.message:findi("hail")) then
-    if (e.other:HasItem(64034)) then 
-      --#if have signet of command
+	if (e.message:findi("hail")) then
+		if (e.other:HasItem(64034)) then
 			e.self:Say("You hold a Signet of Command! I can use the power of the signet to [" .. eq.say_link("open the way") .. "] for you to the upper reaches of the temple once you are prepared to face the Tunat'Muram.");
-    else
-      --#if don't have signet of command		
+		else
+			--#if don't have signet of command		
 			e.self:Say("Aaaaahh! You frightened me! I've spent days hiding in the rubble here waiting for someone to come. Thank Trushar it's you and not one of those monsters! I didn't know how much longer I could hold out, but I have information that may [" .. eq.say_link("help") .. "] you rid our island of those vile Muramites and help me get out of this cursed place.");
-    end
-  elseif (e.message:findi("help")) then
+		end
+	elseif (e.message:findi("help")) then
 		e.self:Say("I know the monster that guards this place. He calls himself [" .. eq.say_link("Tkarish") .. "]. I was held captive by the two-headed beast. I don't know exactly what fate awaited me, but the cries of my fellow prisoners were enough to know that it wouldn't have been pleasant.");
-  elseif (e.message:findi("Tkarish")) then
+	elseif (e.message:findi("Tkarish")) then
 		e.self:Say("I believe the full title he demanded his servants use is Zun'Muram Tkarish Zyk. Fortunately, he's as arrogant as he is strong and I was able to slip away when he thought me secure. Unfortunately, he has gained control over the sacred [" .. eq.say_link("constructs") .. "] in the temple so I haven't been able to leave.");
-  elseif (e.message:findi("constructs")) then
+	elseif (e.message:findi("constructs")) then
 		e.self:Say("There are special constructs within this temple that allow access to other areas. The one next to us would normally allow me to leave the temple entirely, but it is under the sway of the Muramites. I overheard Tkarish speaking of a Tunat'Muram, a kind of commander as far as I could tell, that resides within the upper levels of the temple only reachable via the constructs. But Tkarish holds a [" .. eq.say_link("Signet of Command") .. "] which gives him control over the constructs. As long as he has that Signet, the way to the Tunat'Muram is closed to you and the way out is closed to me.");
-  elseif (e.message:findi("signet of command")) then
+	elseif (e.message:findi("signet of command")) then
 		e.self:Say("If you can wrest the signet from Tkarish's grasp, the constructs will allow you passage to the upper levels of the temple. Should you claim a Signet of Command for yourself, I can use it to activate a nearby construct. From here, the influence of your signet would be stronger than the one Tkarish wields in the chapel above and I should be able to convince the construct to grant you passage to the upper levels of the temple.");
-  elseif (e.message:findi("open the way")) then
-    if (e.other:HasItem(64034)) then 
-      --#if have signet of command
-      --#create tacvi instance
-      local request = instance_requests.ValidateRequest('raid', "tacvi", 0, 6, 54, 65, nil, nil, e.other, lockout_globals);
-      -- Only check request.valid here; because when you zone in; the status will calculate which mobs
-      -- are active as each mob has its own lockout.
-      if (request.valid) then 
-        local instance_id = eq.create_instance("tacvi", 0, 21600);              
-        eq.set_global(instance_id.."_tacvi_bit",tostring(request.flags),7,"H6");
-        eq.assign_raid_to_instance(instance_id);                                  
-        e.self:Say("So be it. There is a construct nearby that will bring you to the seat of the slayer himself. May Trushar's blessing infuse your swords with the strength to cleanse this place of the Muramite invaders!");
-      else
-      --#if have signet but not in raid/not have enough
-        e.self:Say("I cannot in good conscience allow you into the upper temple as you are.  If you wish to have any chance against the forces of the Tunat'Muram, you will need the help of many friends.  Without them, I would just be sending you to be slaughtered.");
-      end
-    end
-  end
+	elseif (e.message:findi("open the way")) then
+		local is_gm = (e.other:GetGM())
 
+		if (e.other:HasItem(64034)) then
+			if not is_gm and e.other:GetRaidMemberCountInZone() < 18 then
+				e.other:Message(MT.NPCQuestSay, "Hamari Nedu says, 'I'm sorry, but you don't have enough comrades with you to venture into this dangerous area. Come back when you have at least eighteen friends to join you on this perilous journey.")
+			elseif not is_gm and e.other:DoesAnyPartyMemberHaveLockout(tacvi, "Replay Timer", 54) then
+				e.other:Message(MT.NPCQuestSay, "Hamari Nedu says, 'I'm afraid I cannot allow you to begin, someone in your party has been on this expedition too recently and cannot yet go again.'")
+			else
+				e.other:Message(MT.NPCQuestSay, "Hamari Nedu says, 'Place your hands on one of the altars behind me and the way will be revealed. Be wary for you are about to encounter some of the most vicious trusik known. If for any reason you wish to return, place your hands on the golem within the temple.'");
+				local dz = e.other:CreateExpedition(tacvi_raid)
+			end
+		end
+	end
 end

--- a/txevu/Hamari_Nedu.lua
+++ b/txevu/Hamari_Nedu.lua
@@ -8,25 +8,25 @@ local tacvi_raid = {
 }
 
 function event_say(e) 
-	if (e.message:findi("hail")) then
-		if (e.other:HasItem(64034)) then
+	if e.message:findi("hail") then
+		if e.other:HasItem(64034) then
 			e.self:Say("You hold a Signet of Command! I can use the power of the signet to [" .. eq.say_link("open the way") .. "] for you to the upper reaches of the temple once you are prepared to face the Tunat'Muram.");
 		else
 			--#if don't have signet of command		
 			e.self:Say("Aaaaahh! You frightened me! I've spent days hiding in the rubble here waiting for someone to come. Thank Trushar it's you and not one of those monsters! I didn't know how much longer I could hold out, but I have information that may [" .. eq.say_link("help") .. "] you rid our island of those vile Muramites and help me get out of this cursed place.");
 		end
-	elseif (e.message:findi("help")) then
+	elseif e.message:findi("help") then
 		e.self:Say("I know the monster that guards this place. He calls himself [" .. eq.say_link("Tkarish") .. "]. I was held captive by the two-headed beast. I don't know exactly what fate awaited me, but the cries of my fellow prisoners were enough to know that it wouldn't have been pleasant.");
-	elseif (e.message:findi("Tkarish")) then
+	elseif e.message:findi("Tkarish") then
 		e.self:Say("I believe the full title he demanded his servants use is Zun'Muram Tkarish Zyk. Fortunately, he's as arrogant as he is strong and I was able to slip away when he thought me secure. Unfortunately, he has gained control over the sacred [" .. eq.say_link("constructs") .. "] in the temple so I haven't been able to leave.");
-	elseif (e.message:findi("constructs")) then
+	elseif e.message:findi("constructs") then
 		e.self:Say("There are special constructs within this temple that allow access to other areas. The one next to us would normally allow me to leave the temple entirely, but it is under the sway of the Muramites. I overheard Tkarish speaking of a Tunat'Muram, a kind of commander as far as I could tell, that resides within the upper levels of the temple only reachable via the constructs. But Tkarish holds a [" .. eq.say_link("Signet of Command") .. "] which gives him control over the constructs. As long as he has that Signet, the way to the Tunat'Muram is closed to you and the way out is closed to me.");
-	elseif (e.message:findi("signet of command")) then
+	elseif e.message:findi("signet of command") then
 		e.self:Say("If you can wrest the signet from Tkarish's grasp, the constructs will allow you passage to the upper levels of the temple. Should you claim a Signet of Command for yourself, I can use it to activate a nearby construct. From here, the influence of your signet would be stronger than the one Tkarish wields in the chapel above and I should be able to convince the construct to grant you passage to the upper levels of the temple.");
-	elseif (e.message:findi("open the way")) then
-		local is_gm = (e.other:GetGM())
+	elseif e.message:findi("open the way") then
+		local is_gm = e.other:GetGM();
 
-		if (e.other:HasItem(64034)) then
+		if e.other:HasItem(64034) then
 			if not is_gm and e.other:GetRaidMemberCountInZone() < 18 then
 				e.other:Message(MT.NPCQuestSay, "Hamari Nedu says, 'I'm sorry, but you don't have enough comrades with you to venture into this dangerous area. Come back when you have at least eighteen friends to join you on this perilous journey.")
 			elseif not is_gm and e.other:DoesAnyPartyMemberHaveLockout(tacvi, "Replay Timer", 54) then

--- a/txevu/player.lua
+++ b/txevu/player.lua
@@ -8,17 +8,17 @@ local tacvi_raid = {
 }
 
 function event_click_door(e)
-	local is_gm = (e.self:GetGM())
+	local is_gm = e.self:GetGM();
 	local door_id = e.door:GetDoorID();
 	local entity_list = eq.get_entity_list();
 
-	if (door_id == 55) then -- Bloodfeaster
-		if (eq.get_entity_list():IsMobSpawnedByNpcTypeID(297082)) then
+	if door_id == 55 then -- Bloodfeaster
+		if eq.get_entity_list():IsMobSpawnedByNpcTypeID(297082) then
 			eq.signal(297082,1); --signal Bloodfeaster to initiate sequence
 		end
-	elseif (door_id == 23) then -- Zun Statue
-		if ( e.self:GetInventory():HasItem(64034, 1, 32) == Slot.Cursor) then 
-			if (eq.get_entity_list():IsMobSpawnedByNpcTypeID(297150) == false) then 
+	elseif door_id == 23 then -- Zun Statue
+		if e.self:GetInventory():HasItem(64034, 1, 32) == Slot.Cursor then 
+			if not eq.get_entity_list():IsMobSpawnedByNpcTypeID(297150) then 
 				if not is_gm and e.self:GetRaidMemberCountInZone() < 18 then
 					e.self:Message(MT.NPCQuestSay, "You don't have enough comrades with you to venture into this dangerous area. Come back when you have at least eighteen friends to join you on this perilous journey.")
 				elseif not is_gm and e.self:DoesAnyPartyMemberHaveLockout(tacvi, "Replay Timer", 54) then
@@ -32,27 +32,27 @@ function event_click_door(e)
 			if dz.valid then
 				e.self:MovePCDynamicZone("tacvi") 
 			else
-				e.self:Message(13,"The gateway to the seat of the slaver is sealed off to you. Perhaps you would be able to enter if you needed to adventure there.");
+				e.self:Message(MT.Red,"The gateway to the seat of the slaver is sealed off to you. Perhaps you would be able to enter if you needed to adventure there.");
 			end
 		end
-	elseif (door_id == 25) then -- Zone in Statue
+	elseif door_id == 25 then -- Zone in Statue
 		local dz = e.self:GetExpedition()
 		if dz.valid then
 			e.self:MovePCDynamicZone("tacvi") 
 		else
-			e.self:Message(13,"The gateway to the seat of the slaver is sealed off to you. Perhaps you would be able to enter if you needed to adventure there.");
+			e.self:Message(MT.Red,"The gateway to the seat of the slaver is sealed off to you. Perhaps you would be able to enter if you needed to adventure there.");
 		end
-	elseif (door_id == 10 or door_id == 21) then -- Zun Door
-		if (door_id == 10 and e.self:HasItem(17288)) then
+	elseif door_id == 10 or door_id == 21 then -- Zun Door
+		if door_id == 10 and e.self:HasItem(17288) then
 			entity_list:FindDoor(21):ForceOpen(e.self);
-		elseif (door_id == 21 and e.self:HasItem(17288)) then
+		elseif door_id == 21 and e.self:HasItem(17288) then
 			entity_list:FindDoor(10):ForceOpen(e.self);
 		end
 	end
 end
 
 function event_enter_zone(e)
-	if ( e.self:GetBindZoneID() == 297 ) then    
+	if e.self:GetBindZoneID() == 297 then    
 		e.self:Message(1, "Illegal Bind!")
 		e.self:MovePC(69,840,70,0,0)
 	end

--- a/txevu/player.lua
+++ b/txevu/player.lua
@@ -1,55 +1,59 @@
---Zun doors, if one, open both, key is Jade Inlaid Key
+local tacvi = "Tacvi, Seat of the Slaver"
+local tacvi_raid = {
+	expedition = { name="Tacvi, Seat of the Slaver", min_players=18, max_players=54 },
+	instance   = { zone="tacvi", version=0, duration=eq.seconds("6h") },
+	compass    = { zone="txevu", x=1575.46, y=1745.46, z=-397.62 },
+	safereturn = { zone="txevu", x=-325, y=0, z=-422.12, h=128 },
+	zonein     = { x=4, y=9, z=-6.87, h=376 }
+}
 
-local instance_requests = require("instance_requests");
-local lockout_globals = {
-      { "Tacvi_PXK", "Tacvi: Pixtt Xxeric Kex" },
-      { "Tacvi_PKK", "Tacvi: Pixtt Kretv Krakxt" },
-      { "Tacvi_PRT", "Tacvi: Pixtt Riel Tavas" },
-      { "Tacvi_ZMKP", "Tacvi: Zun`Muram Kvxe Pirik" },
-      { "Tacvi_ZMSB", "Tacvi: Zun`Muram Shaldn Boc" },
-      { "Tacvi_ZMMD", "Tacvi: Zun`Muram Mordl Delt" },
-      { "Tacvi_ZMYV", "Tacvi: Zun`Muram Yihst Vor" },   
-      { "Tacvi_TMCV", "Tacvi: Tunat`Muram Cuu Vauax" }
-		}
----
--- @param Client#event_click_door e
 function event_click_door(e)
-  local door_id = e.door:GetDoorID();
-  local entity_list = eq.get_entity_list();
-  if (door_id == 55) then --Bloodfeaster
-    if (eq.get_entity_list():IsMobSpawnedByNpcTypeID(297082)) then
-      eq.signal(297082,1); --signal Bloodfeaster to initiate sequence
-    end
-  elseif (door_id == 25 or door_id == 23) then 
-    local instance_id = eq.get_instance_id("tacvi",0);       
-    if (instance_id > 0) then                                  
-      e.self:MovePCInstance(298, instance_id, 4.00, 9.00, -6.87, 376); -- Zone: precipiceofwar   
-    else                                                       
-      e.self:Message(13, "You are not a part of an instance!");
-    end                                                        
-  elseif (( door_id == 10 or door_id == 21 ) ) then
-    if (door_id == 10 and e.self:HasItem(17288)) then
-      entity_list:FindDoor(21):ForceOpen(e.self);
-    elseif (door_id == 21 and e.self:HasItem(17288)) then
-      entity_list:FindDoor(10):ForceOpen(e.self);
-    end
-    if ( e.self:GetInventory():HasItem(17288, 1, 32) == Slot.Cursor) then 
-      if (eq.get_entity_list():IsMobSpawnedByNpcTypeID(297150) == false) then 
-        local request = instance_requests.ValidateRequest('raid', "tacvi", 0, 6, 54, 65, nil, nil, e.self, lockout_globals);
-        if (request.valid) then                                                     
-          local instance_id = eq.create_instance("tacvi", 0, 21600);              
-          eq.set_global(instance_id.."_tacvi_bit",tostring(request.flags),7,"H6");
-          eq.assign_raid_to_instance(instance_id);                                  
-          e.self:Message(13, "Added to instance.");
-        end
-      end
-    end
-  end
+	local is_gm = (e.self:GetGM())
+	local door_id = e.door:GetDoorID();
+	local entity_list = eq.get_entity_list();
+
+	if (door_id == 55) then -- Bloodfeaster
+		if (eq.get_entity_list():IsMobSpawnedByNpcTypeID(297082)) then
+			eq.signal(297082,1); --signal Bloodfeaster to initiate sequence
+		end
+	elseif (door_id == 23) then -- Zun Statue
+		if ( e.self:GetInventory():HasItem(64034, 1, 32) == Slot.Cursor) then 
+			if (eq.get_entity_list():IsMobSpawnedByNpcTypeID(297150) == false) then 
+				if not is_gm and e.self:GetRaidMemberCountInZone() < 18 then
+					e.self:Message(MT.NPCQuestSay, "You don't have enough comrades with you to venture into this dangerous area. Come back when you have at least eighteen friends to join you on this perilous journey.")
+				elseif not is_gm and e.self:DoesAnyPartyMemberHaveLockout(tacvi, "Replay Timer", 54) then
+					e.self:Message(MT.NPCQuestSay, "Someone in your party has been on this expedition too recently and cannot yet go again.'")
+				else
+					local dz = e.self:CreateExpedition(tacvi_raid)
+				end
+			end
+		else
+			local dz = e.self:GetExpedition()
+			if dz.valid then
+				e.self:MovePCDynamicZone("tacvi") 
+			else
+				e.self:Message(13,"The gateway to the seat of the slaver is sealed off to you. Perhaps you would be able to enter if you needed to adventure there.");
+			end
+		end
+	elseif (door_id == 25) then -- Zone in Statue
+		local dz = e.self:GetExpedition()
+		if dz.valid then
+			e.self:MovePCDynamicZone("tacvi") 
+		else
+			e.self:Message(13,"The gateway to the seat of the slaver is sealed off to you. Perhaps you would be able to enter if you needed to adventure there.");
+		end
+	elseif (door_id == 10 or door_id == 21) then -- Zun Door
+		if (door_id == 10 and e.self:HasItem(17288)) then
+			entity_list:FindDoor(21):ForceOpen(e.self);
+		elseif (door_id == 21 and e.self:HasItem(17288)) then
+			entity_list:FindDoor(10):ForceOpen(e.self);
+		end
+	end
 end
 
 function event_enter_zone(e)
-  if ( e.self:GetBindZoneID() == 297 ) then    
-    e.self:Message(1, "Illegal Bind!")
-    e.self:MovePC(69,840,70,0,0)
-  end
+	if ( e.self:GetBindZoneID() == 297 ) then    
+		e.self:Message(1, "Illegal Bind!")
+		e.self:MovePC(69,840,70,0,0)
+	end
 end


### PR DESCRIPTION
- Minor revamp of Tacvi scripts using PEQ's as a base
- Full DZ Support with lockouts at each appropriate stage.
- Doors will now properly lock zone wide during fights
- Tunat phase 2 complete overhaul
- most fights have had adjustments to their mechanics
- Minimum Players 18, Maximum 54
- To start instance, you can use Hamari (Make sure key is on your cursor when chatting). Or use the status behind ZMTZ when he is dead (Make sure key is on your cursor, will need to use the "U" key to click on it if using RoF2).