### PR TITLE
Check delivered task items in trade plugins

### DIFF
--- a/lua_modules/items.lua
+++ b/lua_modules/items.lua
@@ -86,15 +86,20 @@ function items.return_items(npc, client, trade, text)
 	for i = 1, 4 do
 		local inst = trade["item" .. i];
 		if(inst.valid) then
+			-- remove delivered task items from return for this slot
+			local return_count = inst:RemoveTaskDeliveredItems()
+
 			if(eq.is_disc_tome(inst:GetID()) and npc:GetClass() > 19 and npc:GetClass() < 36) then
 				if(client:GetClass() == npc:GetClass() - 19) then
 					client:TrainDisc(inst:GetID());
 				else
 					npc:Say(string.format("You are not a member of my guild. I will not train you!"));
-					client:PushItemOnCursor(inst);
-					returned = true;
+					if return_count > 0 then
+						client:PushItemOnCursor(inst);
+						returned = true;
+					end
 				end
-			else
+			elseif return_count > 0 then
 				client:PushItemOnCursor(inst);
 				if(text == true) then
 					npc:Say(string.format("I have no need for this %s, you can have it back.", client:GetCleanName()));

--- a/plugins/check_handin.pl
+++ b/plugins/check_handin.pl
@@ -25,12 +25,12 @@ sub return_items {
 	my $items_returned = 0;
 
 	my %ItemHash = (
-		0 => [ plugin::val('$item1'), plugin::val('$item1_charges'), plugin::val('$item1_attuned') ],
-		1 => [ plugin::val('$item2'), plugin::val('$item2_charges'), plugin::val('$item2_attuned') ],
-		2 => [ plugin::val('$item3'), plugin::val('$item3_charges'), plugin::val('$item3_attuned') ],
-		3 => [ plugin::val('$item4'), plugin::val('$item4_charges'), plugin::val('$item4_attuned') ],
+		0 => [ plugin::val('$item1'), plugin::val('$item1_charges'), plugin::val('$item1_attuned'), plugin::val('$item1_inst') ],
+		1 => [ plugin::val('$item2'), plugin::val('$item2_charges'), plugin::val('$item2_attuned'), plugin::val('$item2_inst') ],
+		2 => [ plugin::val('$item3'), plugin::val('$item3_charges'), plugin::val('$item3_attuned'), plugin::val('$item3_inst') ],
+		3 => [ plugin::val('$item4'), plugin::val('$item4_charges'), plugin::val('$item4_attuned'), plugin::val('$item4_inst') ],
 	);
-	
+
 	foreach my $k (keys(%{$hashref}))
 	{
 		next if($k == 0);
@@ -42,9 +42,16 @@ sub return_items {
 			{
 				if ($client)
 				{
-					$client->SummonItem($k, $ItemHash{$r}[1], $ItemHash{$r}[2]);
-					quest::say("I have no need for this $name, you can have it back.");
-					$items_returned = 1;
+					# remove delivered task items from return for this slot
+					my $inst = $ItemHash{$r}[3];
+					my $return_count = $inst->RemoveTaskDeliveredItems();
+
+					if ($return_count > 0)
+					{
+						$client->SummonItem($k, $inst->GetCharges(), $ItemHash{$r}[2]);
+						quest::say("I have no need for this $name, you can have it back.");
+						$items_returned = 1;
+					}
 				}
 				else
 				{


### PR DESCRIPTION
This will make the Lua items module and Perl check_handin plugin not return items consumed by source task delivery updates when source is patched to restore sending delivered task items in EVENT_TRADE.

Note the trade plugins do not handle item stacks so if a trade slot is consumed by a plugin check, any extra items in the stack will not be returned even if not all were used by a task update.

Do not merge this until/unless https://github.com/EQEmu/Server/pull/2518 is merged into PEQ