### PR TITLE
[Handin] Fix issues with Perl/Lua handin plugins

### DIFF
--- a/lua_modules/items.lua
+++ b/lua_modules/items.lua
@@ -109,6 +109,11 @@ function items.return_items(npc, client, trade, text)
 	for i = 1, 4 do
 		local inst = trade["item" .. i];
 		if(inst.valid) then
+			local is_attuned = 0;
+			if inst:IsInstNoDrop() then
+				is_attuned = 1;
+			end
+
 			-- remove delivered task items from return for this slot
 			local return_count = inst:RemoveTaskDeliveredItems()
 


### PR DESCRIPTION
### What

This resolves some issues with handin plugins. After investigating crashes on PEQ this is coupled with source changes that also need to go in. 

https://github.com/EQEmu/Server/pull/2945

https://github.com/EQEmu/Server/pull/2944

* Lua (items.lua) was not properly capturing the `is_attuned` during returned item recording causing a `nil` error and breaking handins
* Perl (check_handin.pl) Was not capturing items when handled during task delivery
* Perl (check_handin.pl) Money now is handled unified with the required items hash
* Perl (check_handin.pl) Was not capturing items when handled during task delivery
* Perl (check_handin.pl) Charges is now being recorded properly on handin events
* Perl (check_handin.pl) Attuned is now being recorded properly on handin events

### Testing

Did hours of local testing, going through many scenarios.

* Handing in only money, getting proper return when we didn't meet exact
* Handing in items with money when there are required items but not required money, with money returned
* Handing in items with money with only money required and items returned

![image](https://user-images.githubusercontent.com/3319450/219612633-3ab769b8-cf34-41b5-b7bd-9e8051773f7a.png)

![image](https://user-images.githubusercontent.com/3319450/219612665-00ac3d89-ae0c-4c58-8734-17f4692e6dc0.png)

![image](https://user-images.githubusercontent.com/3319450/219612684-0191009b-56b6-4171-9175-05f324bd15f5.png)

![image](https://user-images.githubusercontent.com/3319450/219612706-24ff3af3-69f8-4463-a0e8-aab1a80ae273.png)
