### PR TITLE
Lock veteran to dragons

### DIFF
--- a/global/global_player.lua
+++ b/global/global_player.lua
@@ -231,15 +231,23 @@ vet_aa = {
     [600]  = {441504000, true, true}, -- Blessing of the Devoted 14 yr
 }
 
+
 function event_connect(e)
+	grant_veteran_aa(e)
+    don.fix_invalid_faction_state(e.self)
+end
+
+function grant_veteran_aa(e)
+	if not eq.is_dragons_of_norrath_enabled() then
+		return
+	end
+
     local age = e.self:GetAccountAge();
     for aa, v in pairs(vet_aa) do
         if v[3] and (v[2] or age >= v[1]) then
             e.self:GrantAlternateAdvancementAbility(aa, 1)
         end
     end
-
-    don.fix_invalid_faction_state(e.self)
 end
 
 --[[


### PR DESCRIPTION
This PR does two things:

- First, puts veteran AA's into a function
- Second, adds a check that Dragons of Norrath expansion is enabled, gating veteran AAs until the expansion is enabled.

From a quick search, veteran AAs were not introduced until 2005. That's roughly the time of dragons.
We can always lower this expansion if we find it to be preferred later.

However, the key aspect is new server admins doing a TLP server won't have to do this edit any more.