### PR TITLE
Fix mysterious_voice

### DIFF
--- a/akanon/player.lua
+++ b/akanon/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Flapti Bizttrin has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/cabeast/player.pl
+++ b/cabeast/player.pl
@@ -1,5 +1,5 @@
 sub EVENT_ENTERZONE {
-  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid)) {
+  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid) && quest::is_lost_dungeons_of_norrath_enabled()) {
     $client->Message(15, "A mysterious voice whispers to you, 'Zauz Malgorne has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   }
 }

--- a/cabwest/player.pl
+++ b/cabwest/player.pl
@@ -1,5 +1,5 @@
 sub EVENT_ENTERZONE {
-  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid)) {
+  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid) && quest::is_lost_dungeons_of_norrath_enabled()) {
     $client->Message(15, "A mysterious voice whispers to you, 'Yzilimn Pxikn has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   }
 }

--- a/corathus/player.pl
+++ b/corathus/player.pl
@@ -1,6 +1,6 @@
 sub EVENT_ENTERZONE
 {
-	if(!defined($qglobals{Wayfarer}) && $ulevel >= 15)
+	if(!defined($qglobals{Wayfarer}) && $ulevel >= 15 && quest::is_lost_dungeons_of_norrath_enabled())
 	{
 		$client->Message(15,"A mysterious voice whispers to you, 'If you can feel me in your thoughts, know this -- something is changing in the world and I reckon you should be a part of it. I do not know much, but I do know that in every home city and the wilds there are agents of an organization called the Wayfarers Brotherhood. They are looking for recruits . . . If you can hear this message, you are one of the chosen. Rush to your home city, or search the West Karanas and Rathe Mountains for a contact if you have been exiled from your home for your deeds, and find out more. Adventure awaits you, my friend.'");
 	}
@@ -78,7 +78,7 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				$danika->Say("Great work! With this you have helped feed our troops until tomorrow.");
 			}
-			
+
 			if(defined($qglobals{starshatter_points}))
 			{
 				quest::setglobal("starshatter_points", 10 + $qglobals{starshatter_points}, 5, "D30");
@@ -102,7 +102,7 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				$danika->Say("Great!! I've missed Rivervale so, this should last me a while.");
 			}
-			
+
 			if(defined($qglobals{starshatter_points}))
 			{
 				quest::setglobal("starshatter_points", 10 + $qglobals{starshatter_points}, 5, "D30");
@@ -126,7 +126,7 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				$danika->Say("Great work! With this you have helped feed our troops until tomorrow.");
 			}
-			
+
 			if(defined($qglobals{starshatter_points}))
 			{
 				quest::setglobal("starshatter_points", 5 + $qglobals{starshatter_points}, 5, "D30");
@@ -137,8 +137,8 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				quest::setglobal("starshatter_points", 5, 5, "D30");
 				$client->Message(15, "You have gained Starshatter points, you now have 5 points to spend.");
-			}			
-		}	
+			}
+		}
 	}
 	elsif($task_id = 500153)
 	{
@@ -150,7 +150,7 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				$danika->Say("Great work! With this you have helped feed our troops until tomorrow.");
 			}
-			
+
 			if(defined($qglobals{starshatter_points}))
 			{
 				quest::setglobal("starshatter_points", 5 + $qglobals{starshatter_points}, 5, "D30");
@@ -161,7 +161,7 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				quest::setglobal("starshatter_points", 5, 5, "D30");
 				$client->Message(15, "You have gained Starshatter points, you now have 5 points to spend.");
-			}			
+			}
 		}
 	}
 	elsif($task_id >= 500147 && $task_id <= 500149)
@@ -173,7 +173,7 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				$danika->Say("Excellent soldier, your bravery is to be rewarded.");
 			}
-			
+
 			if(defined($qglobals{starshatter_points}))
 			{
 				quest::setglobal("starshatter_points", 100 + $qglobals{starshatter_points}, 5, "D30");
@@ -184,7 +184,7 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				quest::setglobal("starshatter_points", 100, 5, "D30");
 				$client->Message(15, "You have gained Starshatter points, you now have 100 points to spend.");
-			}			
+			}
 		}
 	}
 	elsif($task_id >= 500154 && $task_id <= 500156)
@@ -198,13 +198,13 @@ sub EVENT_TASK_STAGE_COMPLETE
 				$boss_check = $entity_list->GetMobByNpcTypeID(365035);
 			}
 		}
-		
+
 		my $variable_points = 10;
 		if(!$boss_check)
 		{
 			$variable_points = 5;
 		}
-		
+
 		if($activity_id == 1)
 		{
 			my $izzik = $entity_list->GetMobByNpcTypeID(365146);
@@ -212,7 +212,7 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				$danika->Say("Perfect! I might need more materials later so be sure to check in.");
 			}
-			
+
 			if(defined($qglobals{starshatter_points}))
 			{
 				quest::setglobal("starshatter_points", $variable_points + $qglobals{starshatter_points}, 5, "D30");
@@ -223,7 +223,7 @@ sub EVENT_TASK_STAGE_COMPLETE
 			{
 				quest::setglobal("starshatter_points", $variable_points, 5, "D30");
 				$client->Message(15, "You have gained Starshatter points, you now have $variable_points points to spend.");
-			}			
+			}
 		}
 	}
 }

--- a/crescent/player.pl
+++ b/crescent/player.pl
@@ -48,7 +48,7 @@ sub EVENT_TASK_STAGE_COMPLETE {
 }
 
 sub EVENT_ENTERZONE {
-  if (($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid)) {
+  if (($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid) && quest::is_lost_dungeons_of_norrath_enabled()) {
     $client->Message(15, "A mysterious voice whispers to you, 'Vladnelg Galvern has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   }
 }

--- a/erudnext/player.lua
+++ b/erudnext/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Orwin Flintmaker has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/erudnint/player.lua
+++ b/erudnint/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Ienala Eceiaiu has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/felwithea/player.lua
+++ b/felwithea/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Larroniae Huial has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/felwitheb/player.lua
+++ b/felwitheb/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Thwinose Vilgarn has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/freeporteast/player.lua
+++ b/freeporteast/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Miocaei Herlsas has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/freeportwest/player.lua
+++ b/freeportwest/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Genniau Noghce has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/freporte/player.lua
+++ b/freporte/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Miocaei Herlsas has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/freportn/player.lua
+++ b/freportn/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Genniau Noghce has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/gfaydark/player.lua
+++ b/gfaydark/player.lua
@@ -5,7 +5,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-	if qglobals.Wayfarer ~= nil and level >= 15 and e.self:GetStartZone() == zoneid then
+	if qglobals.Wayfarer ~= nil and level >= 15 and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled() then
 		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Enyaanuia Windancer in the tavern by Trueshots Bows has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
 	end
 end

--- a/global/global_player.lua
+++ b/global/global_player.lua
@@ -3,27 +3,38 @@
 local don = require("dragons_of_norrath")
 
 function event_enter_zone(e)
-	local qglobals = eq.get_qglobals(e.self);
-	if e.self:GetLevel() >= 15 and qglobals.Wayfarer == nil then
-		local zoneid = eq.get_zone_id();
-		if e.self:GetStartZone() ~= zoneid and (zoneid == 1 or zoneid == 2 or zoneid == 3 or zoneid == 8 or zoneid == 9 
-		or zoneid == 10 or zoneid == 19 or zoneid == 22 or zoneid == 23 or zoneid == 24 or zoneid == 29 or zoneid == 30 
-		or zoneid == 34 or zoneid == 35 or zoneid == 40 or zoneid == 41 or zoneid == 42 or zoneid == 45 or zoneid == 49 
-		or zoneid == 52 or zoneid == 54 or zoneid == 55 or zoneid == 60 or zoneid == 61 or zoneid == 62 or zoneid == 67 
-		or zoneid == 68 or zoneid == 75 or zoneid == 82 or zoneid == 106 or zoneid == 155 or zoneid == 202 or zoneid == 382 
-		or zoneid == 383 or zoneid == 392 or zoneid == 393 or zoneid == 408) then
-			e.self:Message(MT.Yellow, 
-				"A mysterious voice whispers to you, \'If you can feel me in your thoughts, know this -- "
-				.. "something is changing in the world and I reckon you should be a part of it. I do not know much, but I do know "
-				.. "that in every home city and the wilds there are agents of an organization called the Wayfarers Brotherhood. They "
-				.. "are looking for recruits . . . If you can hear this message, you are one of the chosen. Rush to your home city, or "
-				.. "search the West Karanas and Rathe Mountains for a contact if you have been exiled from your home for your deeds, "
-				.. "and find out more. Adventure awaits you, my friend.\'");
-		end
-	end
+	mysterious_voice(e)
 
-	if eq.get_zone_short_name() == "lavastorm" and e.self:GetGMStatus() >= 80 then 
+	if eq.is_lost_dungeons_of_norrath_enabled() and eq.get_zone_short_name() == "lavastorm" and e.self:GetGMStatus() >= 80 then 
 		e.self:Message(MT.DimGray, "There are GM commands available for Dragons of Norrath, use " .. eq.say_link("#don") .. " to get started")
+	end
+end
+
+function mysterious_voice(e)
+	if not eq.is_lost_dungeons_of_norrath_enabled() then
+		return
+	end
+	local qglobals = eq.get_qglobals(e.self);
+	if e.self:GetLevel() < 15 then
+		return
+	end
+	if qglobals.Wayfarer ~= nil then
+		return
+	end
+	local zoneid = eq.get_zone_id();
+	if e.self:GetStartZone() ~= zoneid and (zoneid == 1 or zoneid == 2 or zoneid == 3 or zoneid == 8 or zoneid == 9 
+	or zoneid == 10 or zoneid == 19 or zoneid == 22 or zoneid == 23 or zoneid == 24 or zoneid == 29 or zoneid == 30 
+	or zoneid == 34 or zoneid == 35 or zoneid == 40 or zoneid == 41 or zoneid == 42 or zoneid == 45 or zoneid == 49 
+	or zoneid == 52 or zoneid == 54 or zoneid == 55 or zoneid == 60 or zoneid == 61 or zoneid == 62 or zoneid == 67 
+	or zoneid == 68 or zoneid == 75 or zoneid == 82 or zoneid == 106 or zoneid == 155 or zoneid == 202 or zoneid == 382 
+	or zoneid == 383 or zoneid == 392 or zoneid == 393 or zoneid == 408) then
+		e.self:Message(MT.Yellow, 
+			"A mysterious voice whispers to you, \'If you can feel me in your thoughts, know this -- "
+			.. "something is changing in the world and I reckon you should be a part of it. I do not know much, but I do know "
+			.. "that in every home city and the wilds there are agents of an organization called the Wayfarers Brotherhood. They "
+			.. "are looking for recruits . . . If you can hear this message, you are one of the chosen. Rush to your home city, or "
+			.. "search the West Karanas and Rathe Mountains for a contact if you have been exiled from your home for your deeds, "
+			.. "and find out more. Adventure awaits you, my friend.\'");
 	end
 end
 

--- a/global/global_player.lua
+++ b/global/global_player.lua
@@ -21,20 +21,59 @@ function mysterious_voice(e)
 	if qglobals.Wayfarer ~= nil then
 		return
 	end
-	local zoneid = eq.get_zone_id();
-	if e.self:GetStartZone() ~= zoneid and (zoneid == 1 or zoneid == 2 or zoneid == 3 or zoneid == 8 or zoneid == 9 
-	or zoneid == 10 or zoneid == 19 or zoneid == 22 or zoneid == 23 or zoneid == 24 or zoneid == 29 or zoneid == 30 
-	or zoneid == 34 or zoneid == 35 or zoneid == 40 or zoneid == 41 or zoneid == 42 or zoneid == 45 or zoneid == 49 
-	or zoneid == 52 or zoneid == 54 or zoneid == 55 or zoneid == 60 or zoneid == 61 or zoneid == 62 or zoneid == 67 
-	or zoneid == 68 or zoneid == 75 or zoneid == 82 or zoneid == 106 or zoneid == 155 or zoneid == 202 or zoneid == 382 
-	or zoneid == 383 or zoneid == 392 or zoneid == 393 or zoneid == 408) then
-		e.self:Message(MT.Yellow, 
+	local zone_id = eq.get_zone_id();
+
+	local voice_zones = {
+		Zone.qeynos,
+		Zone.qeynos2,
+		Zone.qrg,
+		Zone.freportn,
+		Zone.freportw,
+		Zone.freporte,
+		Zone.rivervale,
+		Zone.ecommons,
+		Zone.erudnint,
+		Zone.erudnext,
+		Zone.halas,
+		Zone.everfrost,
+		Zone.nro,
+		Zone.sro,
+		Zone.neriaka,
+		Zone.neriakb,
+		Zone.neriakc,
+		Zone.qcat,
+		Zone.oggok,
+		Zone.grobb,
+		Zone.gfaydark,
+		Zone.akanon,
+		Zone.kaladima,
+		Zone.felwithea,
+		Zone.felwitheb,
+		Zone.kaladimb,
+		Zone.butcher,
+		Zone.paineel,
+		Zone.cabwest,
+		Zone.cabeast,
+		Zone.sharvahl,
+		Zone.poknowledge,
+		Zone.freeporteast,
+		Zone.freeportwest,
+		Zone.northro,
+		Zone.southro,
+		Zone.commonlands
+	};
+
+	for _, zone in pairs(voice_zones) do
+		if zone == zone_id then
+			e.self:Message(MT.Yellow,
 			"A mysterious voice whispers to you, \'If you can feel me in your thoughts, know this -- "
 			.. "something is changing in the world and I reckon you should be a part of it. I do not know much, but I do know "
 			.. "that in every home city and the wilds there are agents of an organization called the Wayfarers Brotherhood. They "
 			.. "are looking for recruits . . . If you can hear this message, you are one of the chosen. Rush to your home city, or "
 			.. "search the West Karanas and Rathe Mountains for a contact if you have been exiled from your home for your deeds, "
 			.. "and find out more. Adventure awaits you, my friend.\'");
+			return
+		end
 	end
 end
 
@@ -45,7 +84,7 @@ function event_combine_validate(e)
 	--	["check_tradeskill"]    = e.tradeskill_id (not active)
 	if (e.recipe_id == 10344) then
 		if (e.validate_type:find("check_zone")) then
-			if (e.zone_id ~= 289 and e.zone_id ~= 290) then
+			if (e.zone_id ~= Zone.tipt and e.zone_id ~= Zone.vxed) then
 				return 1;
 			end
 		end

--- a/global/global_player.pl
+++ b/global/global_player.pl
@@ -1,6 +1,6 @@
 # items: 67704
 sub EVENT_ENTERZONE { #message only appears in Cities / Pok and wherever the Wayfarer Camps (LDON) is in.  This message won't appear in the player's home city.
-  if($ulevel >= 15 && !defined($qglobals{Wayfarer})) {
+  if($ulevel >= 15 && !defined($qglobals{Wayfarer}) && quest::is_lost_dungeons_of_norrath_enabled()) {
     if($client->GetStartZone()!=$zoneid && ($zoneid == 1 || $zoneid == 2 || $zoneid == 3 || $zoneid == 8 || $zoneid == 9 || $zoneid == 10 || $zoneid == 19 || $zoneid == 22 || $zoneid == 23 || $zoneid == 24 || $zoneid == 29 || $zoneid == 30 || $zoneid == 34 || $zoneid == 35 || $zoneid == 40 || $zoneid == 41 || $zoneid == 42 || $zoneid == 45 || $zoneid == 49 || $zoneid == 52 || $zoneid == 54 || $zoneid == 55 || $zoneid == 60 || $zoneid == 61 || $zoneid == 62 || $zoneid == 67 || $zoneid == 68 || $zoneid == 75 || $zoneid == 82 || $zoneid == 106 || $zoneid == 155 || $zoneid == 202 || $zoneid == 382 || $zoneid == 383 || $zoneid == 392 || $zoneid == 393 || $zoneid == 408)) {
 	  $client->Message(15,"A mysterious voice whispers to you, 'If you can feel me in your thoughts, know this -- something is changing in the world and I reckon you should be a part of it. I do not know much, but I do know that in every home city and the wilds there are agents of an organization called the Wayfarers Brotherhood. They are looking for recruits . . . If you can hear this message, you are one of the chosen. Rush to your home city, or search the West Karanas and Rathe Mountains for a contact if you have been exiled from your home for your deeds, and find out more. Adventure awaits you, my friend.'");
 	}
@@ -19,7 +19,7 @@ sub EVENT_COMBINE_VALIDATE {
 			}
 		}
 	}
-	
+
 	return 0;
 }
 

--- a/grobb/player.lua
+++ b/grobb/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Blorgok Gkapbron has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/halas/player.lua
+++ b/halas/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Jowra McGynnall has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/neriakb/player.pl
+++ b/neriakb/player.pl
@@ -16,7 +16,7 @@ sub EVENT_CLICKDOOR {
 }
 
 sub EVENT_ENTERZONE {
-  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid)) {
+  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid) && quest::is_lost_dungeons_of_norrath_enabled()) {
     $client->Message(15, "A mysterious voice whispers to you, 'Kwilrz Vn`Ycxa has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   }
 }

--- a/neriakc/player.pl
+++ b/neriakc/player.pl
@@ -1,5 +1,5 @@
 sub EVENT_ENTERZONE {
-  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid)) {
+  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid) && quest::is_lost_dungeons_of_norrath_enabled()) {
     $client->Message(15, "A mysterious voice whispers to you, 'Torxal Smalane has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   }
 }

--- a/oggok/player.pl
+++ b/oggok/player.pl
@@ -1,5 +1,5 @@
 sub EVENT_ENTERZONE {
-  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid)) {
+  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid) && quest::is_lost_dungeons_of_norrath_enabled()) {
     $client->Message(15, "A mysterious voice whispers to you, 'Puwdap has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   }
 }

--- a/paineel/player.pl
+++ b/paineel/player.pl
@@ -1,5 +1,5 @@
 sub EVENT_ENTERZONE {
-  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid)) {
+  if(($ulevel >= 15) && (!defined($qglobals{Wayfarer})) && ($client->GetStartZone()==$zoneid) && quest::is_lost_dungeons_of_norrath_enabled()) {
     $client->Message(15, "A mysterious voice whispers to you, 'Yenlr Undraie has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   }
 }

--- a/qey2hh1/player.lua
+++ b/qey2hh1/player.lua
@@ -6,7 +6,7 @@ function event_enter_zone(e)
 	local level = e.self:GetLevel();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Melaara Tenwinds has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/qeynos/player.lua
+++ b/qeynos/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Warehnn Awlne has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/qeynos2/player.lua
+++ b/qeynos2/player.lua
@@ -4,7 +4,7 @@ function event_enter_zone(e)
 	local qglobals = eq.get_qglobals(e.self);
 	local client = eq.get_entity_list():GetClientByID(e.self:GetID());
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Drun Vorwig has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 
@@ -13,7 +13,7 @@ function event_enter_zone(e)
 		if (client.valid) then
 			client:MovePC(2,-1096,1262,3,0); --move to corner of zone every time the rogue zones in with the package
 		end
-		
+
 	end
 end
 

--- a/qrg/player.lua
+++ b/qrg/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Narwkend Falgon has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/rathemtn/player.pl
+++ b/rathemtn/player.pl
@@ -1,12 +1,12 @@
-sub EVENT_ENTERZONE 
+sub EVENT_ENTERZONE
 {
-	if($ulevel >= 15 && !defined($qglobals{Wayfarer}))
+	if($ulevel >= 15 && !defined($qglobals{Wayfarer}) && quest::is_lost_dungeons_of_norrath_enabled())
 	{
-		if($race eq "Froglok") 
+		if($race eq "Froglok")
 		{
     			$client->Message(15, "A mysterious voice whispers to you, 'Fipnoc Birribit has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
       		}
-		else 
+		else
 		{
 			$client->Message(15, "A mysterious voice whispers to you, 'Nemeen Pekasr has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
 		}

--- a/rivervale/player.lua
+++ b/rivervale/player.lua
@@ -3,7 +3,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled() and eq.is_lost_dungeons_of_norrath_enabled()) then
     		e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Jimbledorp Heptybak has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
   	end
 end

--- a/sharvahl/player.lua
+++ b/sharvahl/player.lua
@@ -6,7 +6,7 @@ function event_enter_zone(e)
 	local zoneid = eq.get_zone_id();
 	local qglobals = eq.get_qglobals(e.self);
 
-  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid) then
+  	if(level >= 15 and qglobals.Wayfarer == nil and e.self:GetStartZone() == zoneid and eq.is_lost_dungeons_of_norrath_enabled()) then
     	e.self:Message(MT.Yellow, "A mysterious voice whispers to you, 'Vlarha Myticla has just joined the Wayfarers Brotherhood and has some information about them, and how you can start doing odd jobs for them. You looked like the heroic sort, so I wanted to contact you . . . discreetly.'");
 	end
 end
@@ -14,8 +14,8 @@ end
 
 function event_click_door(e)
 	local door_id = e.door:GetDoorID();
-	
-	if (e.self:Class() == "Rogue") then 
+
+	if (e.self:Class() == "Rogue") then
 		if (door_id == 106) then
 			if e.self:HasItem(52007) then
 				eq.spawn2(155346,0,0,-541.79,99.84,-235.62,506.8);


### PR DESCRIPTION
Mysterious voice is a LDoN feature.
If the expansion is disabled, there's no reason for the mysterious voice to direct you to a Magus.

This PR puts the mysterious voice into it's own function, and does some guard logic to ensure the situation is valid.

Also added a check if DoN is enabled for the message in lavastorm.