### PR TITLE
Revise global_combine

### DIFF
--- a/global/global_player.lua
+++ b/global/global_player.lua
@@ -44,13 +44,222 @@ function event_combine_validate(e)
 end
 
 function event_combine_success(e)
+	if combine_oow(e) then
+		return
+	end
+	if combine_god(e) then
+		return
+	end
+
+	if (e.recipe_id == 2182 and eq.is_task_activity_active(8013, 0)) then -- Pumpkin Pie
+			eq.update_task_activity(8013, 0, 1); -- The Hungry Halfling
+		return
+	end
+
+	if (e.recipe_id == 2181 and eq.is_task_activity_active(8013, 1)) then -- Pumpkin Bread
+		eq.update_task_activity(8013, 1, 1); -- The Hungry Halfling
+		return
+	end
+
+	if (e.recipe_id == 7811 and eq.is_task_activity_active(8013, 2)) then -- Spiced Pumpkin Cider
+		eq.update_task_activity(8013, 2, 1); -- The Hungry Halfling
+		return
+	end
+
+	if (e.recipe_id == 2183 and eq.is_task_activity_active(8013, 3)) then -- Pumpkin Shake
+		eq.update_task_activity(8013, 3, 1); -- The Hungry Halfling
+		return
+	end
+end
+
+function combine_oow(e)
+	-- if not eq.is_omens_of_war_enabled() then
+	-- 	return false
+	-- end
+
+	if(e.recipe_id == 19460) then --cleric 1.5
+		e.self:AddEXP(25000);
+		e.self:AddAAPoints(5);
+		e.self:Ding();
+		e.self:Message(MT.Yellow,'You have gained 5 ability points!');
+		eq.set_global("cleric_epic","7",5,"F");
+		return true
+	end
+
+	if(e.recipe_id == 13402 or
+		e.recipe_id == 13403 or
+		e.recipe_id == 13404 or
+		e.recipe_id == 13405) then --rogue 1.5
+
+		e.self:Message(MT.Yellow,"The piece of the metal orb fuses together with the blue diamonds under the intense heat of the forge. As it does, a flurry of images flash through your mind... A ranger and his bear side by side, stoic and unafraid, in a war-torn forest. A bitter tattooed woman with bluish skin wallowing in misery in a waterfront tavern. An endless barrage of crashing thunder and lightning illuminating a crimson brick ampitheater. Two halflings locked in a battle of wits using a checkered board. The images then fade from your mind");
+		return true
+	end
+
+	if(e.recipe_id ==13412) then --ranger 1.5 tree
+		eq.set_global("ranger_epic","3",5,"F");
+		if(eq.get_zone_short_name()=="jaggedpine") then
+			e.self:Message(MT.Yellow,"The seed grows rapidly the moment you push it beneath the soil. It appears at first as a mere shoot, but within moments grows into a stout sapling and then into a gigantic tree. The tree is one you've never seen before. It is the coloration and thick bark of a redwood with the thick bole indicative of the species. The tree is, however, far too short and has spindly branches sprouting from it with beautiful flowers that you would expect on a dogwood. You take all of this in at a glance. It takes you a moment longer to realize that the tree is moving.");
+			eq.spawn2(181222, 0, 0, e.self:GetX()+3,e.self:GetY()+3,e.self:GetZ(),0); -- NPC: Red_Dogwood_Treant
+			return true
+		end
+		e.self:Message(MT.Yellow,"The soil conditions prohibit the seed from taking hold");
+		e.self:SummonItem(72091); -- Item: Fertile Earth
+		e.self:SummonItem(62621); -- Item: Senvial's Blessing
+		e.self:SummonItem(62622); -- Item: Grinbik's Blessing
+		e.self:SummonItem(62844); -- Item: Red Dogwood Seed
+		return true
+	end
+
+	if(e.recipe_id ==13413) then --ranger 1.5 final
+		e.self:AddEXP(25000);
+		e.self:AddAAPoints(5);
+		e.self:Ding();
+		e.self:Message(MT.Yellow,'You have gained 5 ability points!');
+		eq.set_global("ranger_epic","5",5,"F");
+		return true
+	end
+
+	if(e.recipe_id ==19914 or e.recipe_id==19915) then --ranger 2.0
+		e.self:Message(MT.Yellow,'Very Good. Now we must attune the cage to the specific element we wish to free. You will need two items, one must protect from the element and the other must be able to absorb an incredible amount of that element. This is not a simple task. You must first discover the nature of the spirit that you wish to free and then find such items that will allow you to redirect its power. You must know that each spirit represents a specific area within their element and that is what you must focus on, not their element specifically. For example, Grinbik was an earth spirit, but his area of power was fertility. Senvial was a spirit of Water, but his power was in mist and fog.');
+		eq.set_global("ranger_epic","8",5,"F");
+		return true
+	end
+
+	if(e.recipe_id ==19916) then --ranger 2.0
+		e.self:Message(MT.Yellow,"The Red Dogwood Treant speaks to you from within your sword. 'Well done. This should allow me to free a spirit with power over cold and ice. Now you need to find the power that binds the spirit and unleash it where that spirit is bound.'");
+		return true
+	end
+
+	if(e.recipe_id ==19917) then --ranger 2.0
+		if(eq.get_zone_short_name()=="anguish") then
+			eq.spawn2(317113, 0, 0, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- NPC: #Oshimai_Spirit_of_the_High_Air
+		end
+		return true
+	end
+
+	if(e.recipe_id ==19880) then -- paladin 1.5 final
+		e.self:AddEXP(25000);
+		e.self:AddAAPoints(5);
+		e.self:Ding();
+		e.self:Message(MT.Yellow,'You have gained 5 ability points!');
+		eq.set_global("paladin_epic","8",5,"F");
+		e.self:Message(MT.Gray,"As the four soulstones come together, a soft blue light eminates around the dark sword. The soulstones find themselves at home within the sword. A flash occurs and four voices in unison speak in your mind, 'Thank you for saving us and giving us a purpose again. You are truly our savior and our redeemer, and we shall serve you from now on. Thank you, noble knight!")
+		return true
+	end
+
+	if(e.recipe_id == 19882) then --bard 1.5 final
+		e.self:AddEXP(25000);
+		e.self:AddAAPoints(5);
+		e.self:Ding();
+		e.self:Message(MT.Yellow,'You have gained 5 ability points!');
+		eq.set_global("bard15","6",5,"F");
+		return true
+	end
+
+
+	if(e.recipe_id == 19888) then --druid 1.5 feerrott
+		if(eq.get_zone_short_name()=="feerrott") then
+			eq.spawn2(47209, 0, 0, e.self:GetX()+10,e.self:GetY()+10,e.self:GetZ(),0); -- NPC: corrupted_spirit
+			e.self:Message(MT.White,"compelled spirit screams as his essences is forced back into the world of the living. 'What is this? Where am I? Who are you? What do you want from me?");
+			return true
+		end
+		e.self:SummonItem(62827); -- Item: Mangled Head
+		e.self:SummonItem(62828); -- Item: Animating Heads
+		e.self:SummonItem(62836); -- Item: Soul Stone
+		return true
+	end
+
+	if(e.recipe_id ==19892) then -- druid 1.5 final
+		e.self:AddAAPoints(5);
+		e.self:Ding();
+		e.self:Message(MT.Yellow,'You have gained 5 ability points!');
+		eq.set_global("druid_epic","8",5,"F");
+		e.self:SendMarqueeMessage(MT.Yellow, 510, 1, 100, 10000, "You plant the Mind Crystal and the Seed of Living Brambles in the pot. The pot grows warm and immediately you see a vine sprouting from the soil. The vine continues to grow at a tremendous rate. Brambles grow into the heart of the crystal where the core impurity is and split it. They continue to grow at an astounding speed and soon burst the pot and form the Staff of Living Brambles");
+		return true
+	end
+
+	if(e.recipe_id ==19908) then --druid 2.0 sub final
+		if(eq.get_zone_short_name()=="anguish") then
+			eq.spawn2(317115, 0, 0, e.self:GetX()+3,e.self:GetY()+3,e.self:GetZ(),0); -- NPC: #Yuisaha
+			e.self:SummonItem(62883); -- Item: Essence of Rainfall
+			e.self:SummonItem(62876); -- Item: Insulated Container
+			return true
+		end
+		e.self:Message(MT.Yellow,"The rain spirit cannot be reached here");
+		e.self:SummonItem(47100); -- Item: Globe of Discordant Energy
+		e.self:SummonItem(62876); -- Item: Insulated Container
+		e.self:SummonItem(62878); -- Item: Frozen Rain Spirit
+		e.self:SummonItem(62879); -- Item: Everburning Jagged Tree Limb
+		return true
+	end
+
+	if(e.recipe_id ==19909) then --druid 2.0 final
+		e.self:AddEXP(50000);
+		e.self:AddAAPoints(10);
+		e.self:Ding();
+		e.self:Message(MT.Yellow,'You have gained 10 ability points!');
+		eq.set_global("druid_epic","13",5,"F");
+		--e.self:SendMarqueeMessage(MT.Yellow, 510, 1, 100, 10000, "You plant the Mind Crystal and the Seed of Living Brambles in the pot. The pot grows warm and immediately you see a vine sprouting from the soil. The vine continues to grow at a tremendous rate. Brambles grow into the heart of the crystal where the core impurity is and split it. They continue to grow at an astounding speed and soon burst the pot and form the Staff of Living Brambles");
+		return true
+	end
+
+	if(e.recipe_id ==19902) then --warrior 2.0
+		e.self:AddEXP(50000);
+		e.self:AddAAPoints(10);
+		e.self:Ding();
+		e.self:Message(MT.Yellow,'You have gained 10 ability points!');
+		eq.set_global("warrior_epic","21",5,"F");
+		return true
+	end
+
+	if (e.recipe_id == 19893) then -- CLR 2.0
+		e.self:Message(MT.Red, "Omat should probably see this.");
+		return true
+	end
+
+	if (e.recipe_id == 19919) then --ench 2.0
+		eq.set_global("ench_epic","9",5,"F");
+		e.self:Message(MT.Yellow,"Your Oculus of Persuasion gleams with a blinding light for a moment, dimming quickly to its previous understated beauty. The light has left an image burned into your mind, a strangely tattooed woman chanting by a waterfall.");
+		return true
+	end
+	if (e.recipe_id == 19920) then --ench 2.0 final
+		e.self:Message(MT.Yellow,"The discordant energy shoots through the staff, sending a shower of sparks through the air. The crystal shatters before you, and as the sparks fade away you notice the changes in your staff.");
+		e.self:AddEXP(50000);
+		e.self:AddAAPoints(10);
+		e.self:Ding();
+		e.self:Message(MT.Yellow,'You have gained 10 ability points!');
+		eq.set_global("ench_epic","10",5,"F");
+		return true
+	end
+
+	if (e.recipe_id == 19925) then --pal 2.0 final
+		e.self:Message(MT.Yellow,"As you combine all six tokens in the scabbard with Redemption, you feel a tugging at your soul. An energy flows through you as you feel the virtues of your inner self being tugged and tempered into the weapon. For a second you feel drained, but now that feeling has subsided. A final flash of light occurs and a new sword is tempered; Nightbane, Sword of the Valiant");
+		e.self:AddEXP(50000);
+		e.self:AddAAPoints(10);
+		e.self:Ding();
+		e.self:Message(MT.Yellow,'You have gained 10 ability points!');
+		eq.set_global("paladin_epic","11",5,"F");
+		eq.delete_global("paladin_epic_mmcc");
+		eq.delete_global("paladin_epic_hollowc");
+		return true
+	end
+	return false
+end
+
+function combine_god(e)
+	-- if not eq.is_gates_of_discord_enabled() then
+	-- 	return false
+	-- end
 	if (e.recipe_id == 10904 or e.recipe_id == 10905 or e.recipe_id == 10906 or e.recipe_id == 10907) then
 		e.self:Message(MT.Default,
 		"The gem resonates with power as the shards placed within glow unlocking some of the stone's power. "
 		.. "You were successful in assembling most of the stone but there are four slots left to fill, "
 		.. "where could those four pieces be?"
 		);
-	elseif(e.recipe_id == 10903 or e.recipe_id == 10346 or e.recipe_id == 10334) then
+		return true
+	end
+
+	if(e.recipe_id == 10903 or e.recipe_id == 10346 or e.recipe_id == 10334) then
 		local reward = { };
 		reward["melee"] =  { ["10903"] = 67665, ["10346"] = 67660, ["10334"] = 67653 };
 		reward["hybrid"] = { ["10903"] = 67666, ["10346"] = 67661, ["10334"] = 67654 };
@@ -61,148 +270,9 @@ function event_combine_success(e)
 		e.self:SummonItem(reward[ctype][tostring(e.recipe_id)]);
 		e.self:SummonItem(67704); -- Item: Vaifan's Clockwork Gemcutter Tools
 		e.self:Message(MT.Default, "Success");
-	--cleric 1.5
-	elseif(e.recipe_id == 19460) then
-		e.self:AddEXP(25000);
-		e.self:AddAAPoints(5);
-		e.self:Ding();
-		e.self:Message(MT.Yellow,'You have gained 5 ability points!');
-		eq.set_global("cleric_epic","7",5,"F");
-	--rogue 1.5
-	elseif(e.recipe_id == 13402 or e.recipe_id == 13403 or e.recipe_id == 13404 or e.recipe_id == 13405) then
-		e.self:Message(MT.Yellow,"The piece of the metal orb fuses together with the blue diamonds under the intense heat of the forge. As it does, a flurry of images flash through your mind... A ranger and his bear side by side, stoic and unafraid, in a war-torn forest. A bitter tattooed woman with bluish skin wallowing in misery in a waterfront tavern. An endless barrage of crashing thunder and lightning illuminating a crimson brick ampitheater. Two halflings locked in a battle of wits using a checkered board. The images then fade from your mind");
-	--ranger 1.5 tree
-	elseif(e.recipe_id ==13412) then
-		eq.set_global("ranger_epic","3",5,"F");
-		if(eq.get_zone_short_name()=="jaggedpine") then
-			e.self:Message(MT.Yellow,"The seed grows rapidly the moment you push it beneath the soil. It appears at first as a mere shoot, but within moments grows into a stout sapling and then into a gigantic tree. The tree is one you've never seen before. It is the coloration and thick bark of a redwood with the thick bole indicative of the species. The tree is, however, far too short and has spindly branches sprouting from it with beautiful flowers that you would expect on a dogwood. You take all of this in at a glance. It takes you a moment longer to realize that the tree is moving.");			
-			eq.spawn2(181222, 0, 0, e.self:GetX()+3,e.self:GetY()+3,e.self:GetZ(),0); -- NPC: Red_Dogwood_Treant
-		else
-			e.self:Message(MT.Yellow,"The soil conditions prohibit the seed from taking hold");
-			e.self:SummonItem(72091); -- Item: Fertile Earth
-			e.self:SummonItem(62621); -- Item: Senvial's Blessing
-			e.self:SummonItem(62622); -- Item: Grinbik's Blessing
-			e.self:SummonItem(62844); -- Item: Red Dogwood Seed
-		end
-	--ranger 1.5 final
-	elseif(e.recipe_id ==13413) then
-		e.self:AddEXP(25000);
-		e.self:AddAAPoints(5);
-		e.self:Ding();
-		e.self:Message(MT.Yellow,'You have gained 5 ability points!');
-		eq.set_global("ranger_epic","5",5,"F");
-	--ranger 2.0
-	elseif(e.recipe_id ==19914 or e.recipe_id==19915) then
-		e.self:Message(MT.Yellow,'Very Good. Now we must attune the cage to the specific element we wish to free. You will need two items, one must protect from the element and the other must be able to absorb an incredible amount of that element. This is not a simple task. You must first discover the nature of the spirit that you wish to free and then find such items that will allow you to redirect its power. You must know that each spirit represents a specific area within their element and that is what you must focus on, not their element specifically. For example, Grinbik was an earth spirit, but his area of power was fertility. Senvial was a spirit of Water, but his power was in mist and fog.');
-		eq.set_global("ranger_epic","8",5,"F");
-	elseif(e.recipe_id ==19916) then
-		e.self:Message(MT.Yellow,"The Red Dogwood Treant speaks to you from within your sword. 'Well done. This should allow me to free a spirit with power over cold and ice. Now you need to find the power that binds the spirit and unleash it where that spirit is bound.'");	
-	elseif(e.recipe_id ==19917) then
-		if(eq.get_zone_short_name()=="anguish") then
-			eq.spawn2(317113, 0, 0, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- NPC: #Oshimai_Spirit_of_the_High_Air
-		end
-	-- paladin 1.5 final
-	elseif(e.recipe_id ==19880) then
-		e.self:AddEXP(25000);
-		e.self:AddAAPoints(5);
-		e.self:Ding();
-		e.self:Message(MT.Yellow,'You have gained 5 ability points!');	
-		eq.set_global("paladin_epic","8",5,"F");
-		e.self:Message(MT.Gray,"As the four soulstones come together, a soft blue light eminates around the dark sword. The soulstones find themselves at home within the sword. A flash occurs and four voices in unison speak in your mind, 'Thank you for saving us and giving us a purpose again. You are truly our savior and our redeemer, and we shall serve you from now on. Thank you, noble knight!")
-	--bard 1.5 final	
-	elseif(e.recipe_id == 19882) then
-		e.self:AddEXP(25000);
-		e.self:AddAAPoints(5);
-		e.self:Ding();
-		e.self:Message(MT.Yellow,'You have gained 5 ability points!');	
-		eq.set_global("bard15","6",5,"F");
-	--druid 1.5 feerrott
-	elseif(e.recipe_id == 19888) then
-		if(eq.get_zone_short_name()=="feerrott") then
-			eq.spawn2(47209, 0, 0, e.self:GetX()+10,e.self:GetY()+10,e.self:GetZ(),0); -- NPC: corrupted_spirit
-			e.self:Message(MT.White,"compelled spirit screams as his essences is forced back into the world of the living. 'What is this? Where am I? Who are you? What do you want from me?");
-		else
-			e.self:SummonItem(62827); -- Item: Mangled Head
-			e.self:SummonItem(62828); -- Item: Animating Heads
-			e.self:SummonItem(62836); -- Item: Soul Stone
-		end
-	-- druid 1.5 final
-	elseif(e.recipe_id ==19892) then
-		e.self:AddAAPoints(5);
-		e.self:Ding();
-		e.self:Message(MT.Yellow,'You have gained 5 ability points!');	
-		eq.set_global("druid_epic","8",5,"F");	
-		e.self:SendMarqueeMessage(MT.Yellow, 510, 1, 100, 10000, "You plant the Mind Crystal and the Seed of Living Brambles in the pot. The pot grows warm and immediately you see a vine sprouting from the soil. The vine continues to grow at a tremendous rate. Brambles grow into the heart of the crystal where the core impurity is and split it. They continue to grow at an astounding speed and soon burst the pot and form the Staff of Living Brambles");
-	--druid 2.0 sub final
-	elseif(e.recipe_id ==19908) then
-		if(eq.get_zone_short_name()=="anguish") then
-			eq.spawn2(317115, 0, 0, e.self:GetX()+3,e.self:GetY()+3,e.self:GetZ(),0); -- NPC: #Yuisaha
-			e.self:SummonItem(62883); -- Item: Essence of Rainfall
-			e.self:SummonItem(62876); -- Item: Insulated Container
-		else
-			e.self:Message(MT.Yellow,"The rain spirit cannot be reached here");
-			e.self:SummonItem(47100); -- Item: Globe of Discordant Energy
-			e.self:SummonItem(62876); -- Item: Insulated Container
-			e.self:SummonItem(62878); -- Item: Frozen Rain Spirit
-			e.self:SummonItem(62879); -- Item: Everburning Jagged Tree Limb
-		end
-	--druid 2.0 final
-	elseif(e.recipe_id ==19909) then	
-		e.self:AddEXP(50000);
-		e.self:AddAAPoints(10);
-		e.self:Ding();
-		e.self:Message(MT.Yellow,'You have gained 10 ability points!');	
-		eq.set_global("druid_epic","13",5,"F");	
-		--e.self:SendMarqueeMessage(MT.Yellow, 510, 1, 100, 10000, "You plant the Mind Crystal and the Seed of Living Brambles in the pot. The pot grows warm and immediately you see a vine sprouting from the soil. The vine continues to grow at a tremendous rate. Brambles grow into the heart of the crystal where the core impurity is and split it. They continue to grow at an astounding speed and soon burst the pot and form the Staff of Living Brambles");
-	--warrior 2.0
-	elseif(e.recipe_id ==19902) then	
-		e.self:AddEXP(50000);
-		e.self:AddAAPoints(10);
-		e.self:Ding();
-		e.self:Message(MT.Yellow,'You have gained 10 ability points!');	
-		eq.set_global("warrior_epic","21",5,"F");		
-	-- CLR 2.0
-	elseif (e.recipe_id == 19893) then
-		e.self:Message(MT.Red, "Omat should probably see this.");
-	--ench 2.0
-	elseif (e.recipe_id == 19919) then
-		eq.set_global("ench_epic","9",5,"F");
-		e.self:Message(MT.Yellow,"Your Oculus of Persuasion gleams with a blinding light for a moment, dimming quickly to its previous understated beauty. The light has left an image burned into your mind, a strangely tattooed woman chanting by a waterfall.");
-	--ench 2.0 final
-	elseif (e.recipe_id == 19920) then
-		e.self:Message(MT.Yellow,"The discordant energy shoots through the staff, sending a shower of sparks through the air. The crystal shatters before you, and as the sparks fade away you notice the changes in your staff.");
-		e.self:AddEXP(50000);
-		e.self:AddAAPoints(10);
-		e.self:Ding();
-		e.self:Message(MT.Yellow,'You have gained 10 ability points!');
-		eq.set_global("ench_epic","10",5,"F");
-	--pal 2.0 final
-	elseif (e.recipe_id == 19925) then
-		e.self:Message(MT.Yellow,"As you combine all six tokens in the scabbard with Redemption, you feel a tugging at your soul. An energy flows through you as you feel the virtues of your inner self being tugged and tempered into the weapon. For a second you feel drained, but now that feeling has subsided. A final flash of light occurs and a new sword is tempered; Nightbane, Sword of the Valiant");
-		e.self:AddEXP(50000);
-		e.self:AddAAPoints(10);
-		e.self:Ding();
-		e.self:Message(MT.Yellow,'You have gained 10 ability points!');
-		eq.set_global("paladin_epic","11",5,"F");
-		eq.delete_global("paladin_epic_mmcc");
-		eq.delete_global("paladin_epic_hollowc");
-	elseif (e.recipe_id == 2182) then -- Pumpkin Pie
-		if (eq.is_task_activity_active(8013, 0)) then -- The Hungry Halfling
-			eq.update_task_activity(8013, 0, 1);
-		end
-	elseif (e.recipe_id == 2181) then -- Pumpkin Bread
-		if (eq.is_task_activity_active(8013, 1)) then -- The Hungry Halfling
-			eq.update_task_activity(8013, 1, 1);
-		end
-	elseif (e.recipe_id == 7811) then -- Spiced Pumpkin Cider
-		if (eq.is_task_activity_active(8013, 2)) then -- The Hungry Halfling
-			eq.update_task_activity(8013, 2, 1);
-		end
-	elseif (e.recipe_id == 2183) then -- Pumpkin Shake
-		if (eq.is_task_activity_active(8013, 3)) then -- The Hungry Halfling
-			eq.update_task_activity(8013, 3, 1);
-		end
+		return true
 	end
+	return false
 end
 
 function event_command(e)


### PR DESCRIPTION
This is a more aggressive change, so if we don't merge it that's fine.

Add guards instead of large else blocks

Add functions for god/don combines.

Return true on combine success, fail on fail inside functions

Originally I was adding a check for god/don combines on top, if the expansion is enabled, however, I think for this to properly work, we should fail the combine as well on attempt out of era. This way you don't miss a flag or other event triggers.

I can add the combine reject if you do certain recipes when out of era, this is a good prevention for TLP reasons where someone is trying to do a combine prior to expansion release.

But the baseline this PR adds, is still likely useful for foundation