### PR TITLE
Disable Translocator Gethia pre-kunark

### DIFF
--- a/butcher/#Translocator_Gethia.lua
+++ b/butcher/#Translocator_Gethia.lua
@@ -1,5 +1,7 @@
 local helper = require('translocators');
 
 function event_say(e)
-    helper.hail_text(e, 'Timorous Deep', {zone=96, x=-3282, y=-4613, z=19, heading=326});
+    if eq.is_the_ruins_of_kunark_enabled() then
+        helper.hail_text(e, 'Timorous Deep', {zone=96, x=-3282, y=-4613, z=19, heading=326});
+    end
 end


### PR DESCRIPTION
This adds a requirement to Kunark to Gethia.

Ideally we disable the NPC as well, but having the quest + NPC both locked is more ideal.

Currently, when you use her, she translocates you to the safe spot in butcher if you don't have kunark unlocked.