### PR TITLE
[Handin] Item handin overhaul

### DIFF
--- a/lua_modules/items.lua
+++ b/lua_modules/items.lua
@@ -64,7 +64,7 @@ function items.check_turn_in(trade, trade_check)
 end
 
 function items.return_items(npc, client, trade, text)
-	return false
+	client:ReturnHandinItems();
 end
 
 function items.return_bot_items(bot, client, trade, text)

--- a/lua_modules/items.lua
+++ b/lua_modules/items.lua
@@ -57,14 +57,14 @@ function items.check_turn_in(trade, trade_check)
 	end
 
     if (trade.self) then
-        return trade.other:CheckHandin(trade.self, handin_data, required_data, item_data);
+        return trade.self:CheckHandin(trade.other, handin_data, required_data, item_data);
     else
         return false
     end
 end
 
 function items.return_items(npc, client, trade, text)
-	client:ReturnHandinItems();
+	npc:ReturnHandinItems(client);
 end
 
 function items.return_bot_items(bot, client, trade, text)

--- a/lua_modules/items.lua
+++ b/lua_modules/items.lua
@@ -1,175 +1,70 @@
 local items = {}
 
 function items.check_turn_in(trade, trade_check)
-	--create trade_return table == trade
-	--shallow copy
-	local trade_return = {};
-	for key, value in pairs(trade) do
-		trade_return[key] = value;
-	end
+    local handin_data = {};
+    local index = 1;
+    for key, value in pairs(trade) do
+        if (key:findi("item")) then
+            local item_id = value:GetID()
+            if item_id ~= nil and item_id ~= 0 then
+                if handin_data[item_id] ~= nil then
+                    handin_data[item_id] = handin_data[item_id] + 1
+                else
+                    handin_data[item_id] = 1
+                end
+            end
+        end
+    end
 
-	-- Handin table for source
-	local handin_data = {};
-	for x = 1, 4 do
-		local inst = trade["item" .. x];
-		if (inst.valid) then
-			local is_attuned = 0;
-			if inst:IsInstNoDrop() then
-				is_attuned = 1;
-			end
+    local item_data = {};
+    for x = 1, 4 do
+        local inst = trade["item" .. x];
+        if (inst.valid) then
+            item_data[x] = inst
+        end
+    end
 
-			handin_data[x] = string.format("%d|%d|%d", inst:GetID(), inst:GetCharges(), is_attuned);
-		else
-			handin_data[x] = "0|0|0";
+    local required_data = {}
+    for i = 1, 4 do
+        local key = "item" .. i;
+        local item_id = trade_check[key]
+    
+        if item_id ~= nil and item_id ~= 0 then
+            if required_data[item_id] ~= nil then
+                required_data[item_id] = required_data[item_id] + 1
+            else
+                required_data[item_id] = 1
+            end
+        end
+    end
+
+	local currencies = { "platinum", "gold", "silver", "copper" }
+
+	-- Loop through each currency and check the corresponding key in trade_check
+	for _, currency in ipairs(currencies) do
+		if trade_check[currency] ~= nil and trade_check[currency] ~= 0 then
+			-- Process the currency value
+			local amount = trade_check[currency]
+			required_data[currency] = amount
+			-- You can perform your logic here, like adding to total or comparing values
 		end
 	end
 
-	trade.other:SetEntityVariable("HANDIN_ITEMS", items.get_handin_items_serialized(handin_data))
+	for _, currency in ipairs(currencies) do
+		if trade[currency] ~= nil and trade[currency] ~= 0 then
+			handin_data[currency] = trade[currency]
+		end 
+	end
 
-	trade.other:SetEntityVariable("HANDIN_MONEY", string.format("%d|%d|%d|%d", trade.copper, trade.silver, trade.gold, trade.platinum))
-	
-	--for every item in trade_check check trade_return
-		--if item exists in trade_return then 
-			--remove that item from trade_return
-		--else
-			--failure
-	for i = 1, 4 do
-		local key = "item" .. i;
-		if(trade_check[key] ~= nil and trade_check[key] ~= 0) then
-			local found = false;
-			for j = 1, 4 do
-				local inst = trade_return["item" .. j];			
-				if(inst.valid and trade_check[key] == inst:GetID()) then
-					trade_return["item" .. j] = ItemInst();
-					found = true;
-					break;
-				end
-			end
-			
-			if(not found) then
-				return false;
-			end
-		end
-	end
-	
-	--convert our money into copper then check that we have enough then convert change back
-	local trade_check_money = 0;
-	local return_money = 0;
-	
-	if(trade_check["platinum"] ~= nil and trade_check["platinum"] ~= 0) then
-		trade_check_money = trade_check_money + (trade_check["platinum"] * 1000);
-	end
-	
-	if(trade_check["gold"] ~= nil and trade_check["gold"] ~= 0) then
-		trade_check_money = trade_check_money + (trade_check["gold"] * 100);
-	end
-	
-	if(trade_check["silver"] ~= nil and trade_check["silver"] ~= 0) then
-		trade_check_money = trade_check_money + (trade_check["silver"] * 10);
-	end
-	
-	if(trade_check["copper"] ~= nil and trade_check["copper"] ~= 0) then
-		trade_check_money = trade_check_money + trade_check["copper"];
-	end
-	
-	return_money = return_money + trade_return["platinum"] * 1000 + trade_return["gold"] * 100;
-	return_money = return_money + trade_return["silver"] * 10 + trade_return["copper"];
-	
-	if(return_money < trade_check_money) then
-		return false;
-	else
-		return_money = return_money - trade_check_money;
-	end
-	
-	--replace trade with trade_return
-	trade.item1 = trade_return.item1;
-	trade.item2 = trade_return.item2;
-	trade.item3 = trade_return.item3;
-	trade.item4 = trade_return.item4;
-	
-	trade.platinum = math.floor(return_money / 1000);
-	return_money = return_money - (trade.platinum * 1000);
-	
-	trade.gold = math.floor(return_money / 100);
-	return_money = return_money - (trade.gold * 100);
-	
-	trade.silver = math.floor(return_money / 10);
-	return_money = return_money - (trade.silver * 10);
-	
-	trade.copper = return_money;
-	return true;
+    if (trade.self) then
+        return trade.other:CheckHandin(trade.self, handin_data, required_data, item_data);
+    else
+        return false
+    end
 end
 
 function items.return_items(npc, client, trade, text)
-	text = text or true;
-	local returned = false;
-
-	-- Handin table for source
-	local return_data = {};
-	for i = 1, 4 do
-		local inst = trade["item" .. i];
-		if(inst.valid) then
-			local is_attuned = 0;
-			if inst:IsInstNoDrop() then
-				is_attuned = 1;
-			end
-
-			-- remove delivered task items from return for this slot
-			local return_count = inst:RemoveTaskDeliveredItems()
-
-			if(eq.is_disc_tome(inst:GetID()) and npc:GetClass() >= 19 and npc:GetClass() < 36) then
-				if(client:GetClass() == npc:GetClass() - 19) then
-					client:TrainDisc(inst:GetID());
-				else
-					return_data[#return_data+1] = string.format("%d|%d|%d", inst:GetID(), inst:GetCharges(), is_attuned);
-					npc:Say(string.format("You are not a member of my guild. I will not train you!"));
-					if return_count > 0 then
-						client:PushItemOnCursor(inst);
-						returned = true;
-					end
-				end
-			elseif return_count > 0 then
-				return_data[#return_data+1] = string.format("%d|%d|%d", inst:GetID(), inst:GetCharges(), is_attuned);
-				client:PushItemOnCursor(inst);
-				if text then
-					npc:Say(string.format("I have no need for this %s, you can have it back.", client:GetCleanName()));
-				end
-				returned = true;
-			end
-		end
-	end
-
-	client:SetEntityVariable("RETURN_ITEMS", items.get_handin_items_serialized(return_data))
-	
-	local money = false;
-	if(trade.platinum ~= 0) then
-		returned = true;
-		money = true;
-	end
-	
-	if(trade.gold ~= 0) then
-		returned = true;
-		money = true;
-	end
-	
-	if(trade.silver ~= 0) then
-		returned = true;
-		money = true;
-	end
-	
-	if(trade.copper ~= 0) then
-		returned = true;
-		money = true;
-	end
-	
-	if money then
-		client:SetEntityVariable("RETURN_MONEY", string.format("%d|%d|%d|%d", trade.copper, trade.silver, trade.gold, trade.platinum));
-		client:AddMoneyToPP(trade.copper, trade.silver, trade.gold, trade.platinum, true);
-	end
-
-	eq.send_player_handin_event();
-	
-	return returned;
+	return false
 end
 
 function items.return_bot_items(bot, client, trade, text)
@@ -297,10 +192,6 @@ function items.check_bot_turn_in(trade, trade_check)
 	
 	trade.copper = return_money;
 	return true;
-end
-
-function items.get_handin_items_serialized(handin_table)
-	return table.concat(handin_table, ",")
 end
 	
 return items;

--- a/plugins/check_handin.pl
+++ b/plugins/check_handin.pl
@@ -15,7 +15,7 @@ sub check_handin {
 	}
 
     my @item_insts = (plugin::val('item1_inst'), plugin::val('item2_inst'), plugin::val('item3_inst'), plugin::val('item4_inst'));
-    return $client->CheckHandin($npc, \%{$hashref}, \%required, @item_insts);
+    return $npc->CheckHandin($client, \%{$hashref}, \%required, @item_insts);
 }
 
 sub return_items {

--- a/plugins/check_handin.pl
+++ b/plugins/check_handin.pl
@@ -1,148 +1,24 @@
 # plugin::check_handin($item1 => #required_amount,...);
 # autoreturns extra unused items on success
 sub check_handin {
-	use Scalar::Util qw(looks_like_number);
-	my $client = plugin::val('client');
-	my $copper = plugin::val('copper');
-	my $silver = plugin::val('silver');
-	my $gold = plugin::val('gold');
-	my $platinum = plugin::val('platinum');
 	my $hashref = shift;
-
-	my $return_copper   = 0;
-	my $return_silver   = 0;
-	my $return_gold     = 0;
-	my $return_platinum = 0;
-
-	if ($copper > 0) {
-		$hashref->{"copper"} = $copper;
-	}
-	if ($silver > 0) {
-		$hashref->{"silver"} = $silver;
-	}
-	if ($gold > 0) {
-		$hashref->{"gold"} = $gold;
-	}
-	if ($platinum > 0) {
-		$hashref->{"platinum"} = $platinum;
-	}
-
-	$client->SetEntityVariable("HANDIN_MONEY", "$copper|$silver|$gold|$platinum");
-
-	# set money zero values if they don't exist
-	my @money = ("platinum", "gold", "silver", "copper");
-	foreach my $m (@money) {
-		if (!$hashref->{$m}) {
-			$hashref->{$m} = 0;
-		}
-	}
-
-	# for some reason the source is sending this, we'll clean it up
-	if ($hashref->{0}) {
-		delete $hashref->{0};
-	}
-
-	if (!$client->EntityVariableExists("HANDIN_ITEMS")) {
-		$client->SetEntityVariable("HANDIN_ITEMS", plugin::GetHandinItemsSerialized("Handin", %$hashref));
-	}
-
-	# -----------------------------
-	# handin formatting examples
-	# -----------------------------
-	# item_id    => required_count eg (1001 => 1)
-	# "copper"   => copper_amount  eg ("copper" => 1234)
-	# "silver"   => silver_amount
-	# "gold"     => gold_amount
-	# "platinum" => platinum_amount
-	# -----------------------------
 	my %required = @_;
-	foreach my $req (keys %required) {
-		if (!defined $hashref->{$req} || $hashref->{$req} != $required{$req}) {
-			return 0;
+	my $client = plugin::val('client');
+	my $npc = plugin::val('npc');
+	my @currencies = ("platinum", "gold", "silver", "copper");
+
+	foreach my $currency (@currencies) {
+		my $value = plugin::val("\$$currency");
+		if ($value > 0) {
+			$hashref->{$currency} = $value;
 		}
 	}
 
-	foreach my $req (keys %required) {
-		if ($required{$req} < $hashref->{$req}) {
-			$hashref->{$req} -= $required{$req};
-		} else {
-			delete $hashref->{$req};
-		}
-	}
-
-	return 1;
+    my @item_insts = (plugin::val('item1_inst'), plugin::val('item2_inst'), plugin::val('item3_inst'), plugin::val('item4_inst'));
+    return $client->CheckHandin($npc, \%{$hashref}, \%required, @item_insts);
 }
 
 sub return_items {
-	my $hashref = plugin::var('$itemcount');
-	my $client = plugin::val('$client');
-	my $name = plugin::val('$name');
-	my $items_returned = 0;
-
-	my %item_data = (
-		0 => [ plugin::val('$item1'), plugin::val('$item1_charges'), plugin::val('$item1_attuned'), plugin::val('$item1_inst') ],
-		1 => [ plugin::val('$item2'), plugin::val('$item2_charges'), plugin::val('$item2_attuned'), plugin::val('$item2_inst') ],
-		2 => [ plugin::val('$item3'), plugin::val('$item3_charges'), plugin::val('$item3_attuned'), plugin::val('$item3_inst') ],
-		3 => [ plugin::val('$item4'), plugin::val('$item4_charges'), plugin::val('$item4_attuned'), plugin::val('$item4_inst') ],
-	);
-
-	my %return_data = ();	
-
-	foreach my $k (keys(%{$hashref})) {
-		next if ($k eq "copper" || $k eq "silver" || $k eq "gold" || $k eq "platinum" || $k == 0);
-		my $rcount = $hashref->{$k};
-		my $r;
-		for ($r = 0; $r < 4; $r++) {
-			if ($rcount > 0 && $item_data{$r}[0] && $item_data{$r}[0] == $k) {
-				if ($client) {
-					my $inst = $item_data{$r}[3];
-					my $return_count = $inst->RemoveTaskDeliveredItems();
-					if ($return_count > 0) {
-						$client->SummonItem($k, $inst->GetCharges(), $item_data{$r}[2]);
-						$return_data{$r} = [$k, $item_data{$r}[1], $item_data{$r}[2]];
-						$items_returned = 1;
-						next;
-					}
-					$return_data{$r} = [$k, $item_data{$r}[1], $item_data{$r}[2]];
-					$client->SummonItem($k, $item_data{$r}[1], $item_data{$r}[2]);
-					$items_returned = 1;
-				} else {
-					$return_data{$r} = [$k, $item_data{$r}[1], $item_data{$r}[2]];
-					quest::summonitem($k, 0);
-					$items_returned = 1;
-				}
-				$rcount--;
-			}
-		}
-
-		delete $hashref->{$k};
-	}
-
-	# check if we have any money to return
-	my @money = ("platinum", "gold", "silver", "copper");
-	my $returned_money = 0;
-	foreach my $m (@money) {
-		if ($hashref->{$m} && $hashref->{$m} > 0) {
-			$returned_money = 1;
-		}
-	}
-
-	if ($returned_money) {
-		my ($cp, $sp, $gp, $pp) = ($hashref->{"copper"}, $hashref->{"silver"}, $hashref->{"gold"}, $hashref->{"platinum"});
-		$client->AddMoneyToPP($cp, $sp, $gp, $pp, 1);
-		$client->SetEntityVariable("RETURN_MONEY", "$cp|$sp|$gp|$pp");
-	}
-
-	$client->SetEntityVariable("RETURN_ITEMS", plugin::GetHandinItemsSerialized("Return", %return_data));
-
-	if ($items_returned || $returned_money) {
-		quest::say("I have no need for this $name, you can have it back.");
-	}
-
-	quest::send_player_handin_event();
-
-	# Return true if items were returned
-	return ($items_returned || $returned_money);
 }
 
 sub return_bot_items {
@@ -198,139 +74,4 @@ sub return_bot_items {
 	}
 
 	return $items_returned;
-}
-
-sub GetHandinItemsSerialized {
-	my $type = shift;
-	my %hash = @_;
-	my @variables = ();
-
-	my %item_data = (
-		0 => [ plugin::val('$item1'), plugin::val('$item1_charges'), plugin::val('$item1_attuned'), plugin::val('$item1_inst') ],
-		1 => [ plugin::val('$item2'), plugin::val('$item2_charges'), plugin::val('$item2_attuned'), plugin::val('$item2_inst') ],
-		2 => [ plugin::val('$item3'), plugin::val('$item3_charges'), plugin::val('$item3_attuned'), plugin::val('$item3_inst') ],
-		3 => [ plugin::val('$item4'), plugin::val('$item4_charges'), plugin::val('$item4_attuned'), plugin::val('$item4_inst') ],
-	);
-
-	my $hashref = plugin::var('$itemcount'); 
-
-	if ($type eq "Handin") {
-		foreach my $k (keys(%{$hashref})) {
-			next if ($k eq "copper" || $k eq "silver" || $k eq "gold" || $k eq "platinum" || $k == 0);
-			my $rcount = $hashref->{$k};
-			for (my $r = 0; $r < 4; $r++) {
-				if ($rcount > 0 && $item_data{$r}[0] && $item_data{$r}[0] == $k) {
-					my $item_id = $item_data{$r}[0];
-					my $item_charges = $item_data{$r}[1];
-					my $item_attuned = $item_data{$r}[2];
-					push(@variables, $item_id . "|" . $item_charges . "|" . $item_attuned);
-				}
-			}
-		}
-	} else {
-		foreach my $key (keys %hash) {
-			push(@variables, $hash{$key}[0] . "|" . $hash{$key}[1] . "|" . $hash{$key}[2]);
-		}
-	}
-
-	return join(",", @variables);
-}
-
-sub mq_process_items {
-	my $hashref = shift;
-	my $npc = plugin::val('$npc');
-	my $trade = undef;
-	
-	if ($npc->EntityVariableExists("_mq_trade")) {
-		$trade = decode_eqemu_item_hash($npc->GetEntityVariable("_mq_trade")); 
-	} else {
-		$trade = {};
-	}
-	
-	foreach my $k (keys(%{$hashref})) {
-		next if ($k == 0);
-		
-		if (defined $trade->{$k}) {
-			$trade->{$k} = $trade->{$k} + $hashref->{$k};
-		} else {
-			$trade->{$k} = $hashref->{$k};
-		}
-	}
-	
-	my $str = encode_eqemu_item_hash($trade);
-	$npc->SetEntityVariable("_mq_trade", $str);
-}
-
-sub check_mq_handin {
-	my %required = @_;
-	my $npc = plugin::val('$npc');
-	my $trade = undef;
-	
-	if ($npc->EntityVariableExists("_mq_trade")) {
-		$trade = decode_eqemu_item_hash($npc->GetEntityVariable("_mq_trade"));
-	} else {
-		return 0;
-	}
-	
-	foreach my $req (keys %required) {
-		if ((!defined $trade->{$req}) || ($trade->{$req} < $required{$req})) {
-			return 0;
-		}
-	}
-	
-	foreach my $req (keys %required) {
-		if ($required{$req} < $trade->{$req}) {
-			$trade->{$req} -= $required{$req};
-		} else {
-			delete $trade->{$req};
-		}
-	}
-	
-	$npc->SetEntityVariable("_mq_trade", encode_eqemu_item_hash($trade));
-	return 1;
-}
-
-sub clear_mq_handin {
-	my $npc = plugin::val('$npc');
-	$npc->SetEntityVariable("_mq_trade", "");
-}
-
-sub encode_eqemu_item_hash {
-	my $hashref = shift;
-	my $str = "";
-	my $i = 0;
-	
-	foreach my $k (keys(%{$hashref})) {
-		if ($i != 0) {
-			$str .= ",";
-		} else {
-			$i = 1;
-		}
-		
-		$str .= $k;
-		$str .= "=";
-		$str .= $hashref->{$k};
-	}
-	
-	return $str;
-}
-
-sub decode_eqemu_item_hash {
-	my $str = shift;
-	my $hashref = { };
-	
-	my @vals = split(/,/, $str);
-	my $val_len = @vals;
-	for(my $i = 0; $i < $val_len; $i++) {
-		my @subval = split(/=/, $vals[$i]);
-		my $subval_len = @subval;
-		if ($subval_len == 2) {
-			my $key = $subval[0];
-			my $value = $subval[1];
-			
-			$hashref->{$key} = $value;
-		}
-	}
-	
-	return $hashref;
 }

--- a/plugins/guildmasters.pl
+++ b/plugins/guildmasters.pl
@@ -1,29 +1,6 @@
 #looks through the items haded in for discipline tomes,
 #processing them as we find them.
 sub try_tome_handins {
-	my $itemcount = shift;
-	my $isclass = shift;
-	my $expectclass = shift;
-	
-	my @tomes = ();
-	foreach my $i(keys %{$itemcount}) {
-		if(quest::isdisctome($i)) {
-			push(@tomes, $i);
-			delete $itemcount->{$i};
-		}
-	}
-	if(@tomes > 0) {
-		if($isclass eq $expectclass) {
-			foreach my $i(@tomes) {
-				quest::traindisc($i);
-			}
-		} else {
-			quest::say('You are not a member of my guild. I will not train you!');
-			foreach my $i(@tomes) {
-				$itemcount->{$i} = 1;
-			}
-		}
-	}
 }
 
 1;


### PR DESCRIPTION
Associated to server pull request [here](https://github.com/EQEmu/Server/pull/4593), do not merge until ready 

This is a very long overdue overhaul to a complex system. That aims to solve many issues around item handins.

**Why**

* Instead of having separately maintained hand-in logic in Perl and Lua, they both pass-through existing plugins to the source and are handled entirely source side. Reducing bugs, defects and allowing us to far more easily add features.
* Player event records sometimes don't get caught under certain circumstances, now every hand-in no matter whether its handled in quest or not gets captured
* Item handin gets handled the same in both Perl and Lua
* Money handin gets handled the same in both Perl and Lua
* Support multi-quest natively in the source for NPC's who have it enabled
* Heavily simplify item handin logic
* Add comprehensive logging to debug deeper level handin issues

**Catch-all for returning items to players**

* Item loss would occur when a player hands in to an NPC with an empty EVENT_TRADE
* Item loss would occur when a player accidentally hands in to a pet instead of the intended NPC
* Item loss would occur if a script failed to add a "return_items" plugin equivalent with hand-in code
* NPCs with no proper check_handin/return_items would eat items.
* NPCs were returning a **new** item, not the previous item instance (items with augments). Items are simply return as their original instance, with all augments, attuned properties, serial number etc.
* Augments were eaten in Perl when doing handins because we were summoning by item ID instead of the item instance itself.
