### PR TITLE
[RSS] Portal Spawn Fix

### DIFF
--- a/riftseekers/encounters/king.lua
+++ b/riftseekers/encounters/king.lua
@@ -86,20 +86,28 @@ function KingSpawn(e)
 	king			= e.self;
 	princecount		= 0;
 	add_sequence	= 0;
+
+	eq.set_timer("tether", 6 * 1000);
+	eq.set_timer("spawn_delayed", 1000);
+	timerstate[e.self:GetID()] = false;
+end
+
+function KingSpawnDelayed(e) 
 	eq.unique_spawn(334040, 0, 0, -215.000000, -580.000000, -768.375000, 0.000000);	-- Ilsin
 	eq.unique_spawn(334039, 0, 0, -181.529999, -579.500000, -775.599976, 1.6);		-- Cynin
 	eq.unique_spawn(334038, 0, 0, -148.000000, -580.000000, -768.375000, 0);		-- Scyllus
 	eq.unique_spawn(334037, 0, 0, 59.000000, -580.000000, -768.375000, 0);			-- Britalic
 	eq.unique_spawn(334036, 0, 0, 92.400002, -579.369995, -775.599976, 0);			-- Allin
 	eq.unique_spawn(334035, 0, 0, 127.000000, -580.000000, -768.375000, 0);			-- Kiranus
-	eq.set_timer("tether", 6 * 1000);
-	CheckPortals();																	-- need to verify (#repop can break the encounter loading :P)
-	timerstate[e.self:GetID()] = false;
+	CheckPortals();
 end
 
 function KingTimer(e)
 	if e.timer == "tether" then
 		CheckLeash(e);
+	elseif e.timer == "spawn_delayed" then
+		KingSpawnDelayed(e);
+		eq.stop_timer(e.timer);
 	elseif e.timer == "portals" then
 		if e.self:IsEngaged() then
 			eq.set_timer("portals", math.random(40,60) * 1000); -- 40-60 sec
@@ -373,7 +381,6 @@ function event_encounter_load(e)
 	eq.register_npc_event("king", Event.timer, 334110, AddTimer);
 
 	-- spawn portals
-	CheckPortals()
 	local temp = eq.get_entity_list():GetMobByNpcTypeID(334041); -- incase he's up already for some reason
 	if temp.valid then
 		king = temp:CastToNPC();

--- a/riftseekers/encounters/queen.lua
+++ b/riftseekers/encounters/queen.lua
@@ -78,20 +78,28 @@ function QueenSpawn(e)
 	queen = e.self;
 	princesscount = 0;
 	add_sequence = 0;
+
+	eq.set_timer("tether", 6 * 1000);
+	eq.set_timer("spawn_delayed", 1000);
+	timerstate[e.self:GetID()] = false;
+end
+
+function QueenSpawnDelayed(e) 
 	eq.unique_spawn(334048, 0, 0, 25, -725, 308.750000, 0);							-- Zulaqua
 	eq.unique_spawn(334047, 0, 0, 64.239998, -725.890015, 301.559998, 511.200012);	-- Yelnia
 	eq.unique_spawn(334045, 0, 0, 310.910004, -726.130005, 301.464203, 0);			-- Quellon
 	eq.unique_spawn(334043, 0, 0, 387.399994, -727.260010, 301.464233, 0);			-- Puja
 	eq.unique_spawn(334044, 0, 0, 348.929993, -726.700012, 301.464233, 0);			-- Lana
 	eq.unique_spawn(334046, 0, 0, 101.529999, -725.630005, 301.464203, 1.5);		-- Kira
-	eq.set_timer("tether", 6 * 1000);
 	CheckPortals(); -- need to verify (#repop can break the encounter loading :P)
-	timerstate[e.self:GetID()] = false;
 end
 
 function QueenTimer(e)
 	if e.timer == "tether" then
 		CheckLeash(e);
+	elseif e.timer == "spawn_delayed" then
+		QueenSpawnDelayed(e);
+		eq.stop_timer(e.timer);
 	elseif e.timer == "portals" then
 		if e.self:IsEngaged() then
 			eq.set_timer("portals", math.random(40,60) * 1000); -- 40-60 sec
@@ -339,7 +347,6 @@ function event_encounter_load(e)
 	eq.register_npc_event("queen", Event.timer, 334086, AddTimer);
 
 	-- spawn portals
-	CheckPortals();
 	local temp = eq.get_entity_list():GetMobByNpcTypeID(334049); -- incase he's up already for some reason
 	if temp.valid then
 		queen = temp:CastToNPC();


### PR DESCRIPTION
This fixes an issue where RSS portals would stack up when zone state is restored. 

Two things -

* CheckPortal gets ran when the encounter is loaded. The problem with spawning things during encounter registration with no NPC owner attached is that we can't determine anything about zone state being restored at this time. We could potentially add source level fixes for this but for now I've fixed it in the script here.
* Other issue is that there is a race condition of what NPC's are spawned in what order so sometimes on repop portals don't spawn and sometimes the princesses don't spawn. I've adjusted both King and Queen to do a delayed 1 second spawn routine