### PR TITLE
Tacvi Updates:

### DIFF
--- a/tacvi/298009.lua
+++ b/tacvi/298009.lua
@@ -1,0 +1,4 @@
+-- Silius Remains
+function event_death_complete(e)
+	eq.signal(298223,4); -- NPC: zone_status
+end

--- a/tacvi/298010.lua
+++ b/tacvi/298010.lua
@@ -1,0 +1,4 @@
+-- Lyndroh Remains
+function event_death_complete(e)
+	eq.signal(298223,3); -- NPC: zone_status
+end

--- a/tacvi/298011.lua
+++ b/tacvi/298011.lua
@@ -1,0 +1,4 @@
+-- Maddoc Remains
+function event_death_complete(e)
+	eq.signal(298223,5); -- NPC: zone_status
+end

--- a/tacvi/298017.lua
+++ b/tacvi/298017.lua
@@ -1,0 +1,4 @@
+-- Kaikachi Remains
+function event_death_complete(e)
+	eq.signal(298223,16); -- NPC: zone_status
+end

--- a/tacvi/298019.lua
+++ b/tacvi/298019.lua
@@ -1,0 +1,4 @@
+-- Valtron Remains
+function event_death_complete(e)
+	eq.signal(298223,7); -- NPC: zone_status
+end

--- a/tacvi/298022.lua
+++ b/tacvi/298022.lua
@@ -1,0 +1,4 @@
+-- Prathun Remains
+function event_death_complete(e)
+	eq.signal(298223,8); -- NPC: zone_status
+end

--- a/tacvi/298024.lua
+++ b/tacvi/298024.lua
@@ -1,0 +1,4 @@
+-- Vahlara Remains
+function event_death_complete(e)
+	eq.signal(298223,6); -- NPC: zone_status
+end

--- a/tacvi/298030.lua
+++ b/tacvi/298030.lua
@@ -1,0 +1,4 @@
+-- Wijdan Remains
+function event_death_complete(e)
+	eq.signal(298223,11); -- NPC: zone_status
+end

--- a/tacvi/298031.lua
+++ b/tacvi/298031.lua
@@ -1,0 +1,4 @@
+-- Rashere Remains
+function event_death_complete(e)
+	eq.signal(298223,15); -- NPC: zone_status
+end

--- a/tacvi/298033.lua
+++ b/tacvi/298033.lua
@@ -1,0 +1,4 @@
+-- Xenaida Remains
+function event_death_complete(e)
+	eq.signal(298223,10); -- NPC: zone_status
+end

--- a/tacvi/298034.lua
+++ b/tacvi/298034.lua
@@ -1,0 +1,4 @@
+-- Rytan Remains
+function event_death_complete(e)
+	eq.signal(298223,9); -- NPC: zone_status
+end

--- a/tacvi/298036.lua
+++ b/tacvi/298036.lua
@@ -1,0 +1,4 @@
+-- Frizznik Remains
+function event_death_complete(e)
+	eq.signal(298223,13); -- NPC: zone_status
+end

--- a/tacvi/298037.lua
+++ b/tacvi/298037.lua
@@ -1,0 +1,4 @@
+-- Absor Remains
+function event_death_complete(e)
+	eq.signal(298223,12); -- NPC: zone_status
+end

--- a/tacvi/298038.lua
+++ b/tacvi/298038.lua
@@ -1,0 +1,4 @@
+-- Zajeer Remains
+function event_death_complete(e)
+	eq.signal(298223,14); -- NPC: zone_status
+end

--- a/tacvi/encounters/pkk.lua
+++ b/tacvi/encounters/pkk.lua
@@ -1,249 +1,247 @@
 local hatchlings_spawned = 0;
-local hatchlings_killed = 0;
-local PKK_hitpoints = 100; -- Also reset to 100 on wipe
+local hatchlings_killed  = 0;
+local PKK_hitpoints      = 100 -- Also reset to 100 on wipe
 
 function PKK_Spawn(e)
-	e.self:ModSkillDmgTaken(3, -30); -- 2h slashing
-	e.self:ModSkillDmgTaken(1, -30); -- 1h slashing
-	e.self:ModSkillDmgTaken(7, -25); -- archery
+	e.self:ModSkillDmgTaken(3, -30) -- 2h slashing
+	e.self:ModSkillDmgTaken(1, -30) -- 1h slashing
+	e.self:ModSkillDmgTaken(7, -25) -- archery
 	if PKK_hitpoints == 100 then -- First spawn/wipe!
-		eq.set_next_hp_event(90);
-		hatchlings_spawned = 0;
-		hatchlings_killed = 0;
-		eq.signal(298223,2); -- Unlock Doors
+		eq.set_next_hp_event(90)
+		hatchlings_spawned = 0
+		hatchlings_killed = 0
+		eq.signal(298223,2) -- Unlock Doors
 	else -- Respawning because all hatchlings are dead
-		eq.depop_all(298047); -- husk
-		e.self:SetHP(e.self:GetMaxHP() * (PKK_hitpoints / 100.0));
+		eq.depop_all(298047) -- husk
+		e.self:SetHP(e.self:GetMaxHP() * (PKK_hitpoints / 100.0))
 		if PKK_hitpoints == 90 then
-			 eq.set_next_hp_event(70);
+			 eq.set_next_hp_event(70)
 		elseif PKK_hitpoints == 70 then
-			 eq.set_next_hp_event(50);
+			 eq.set_next_hp_event(50)
 		elseif PKK_hitpoints == 50 then
-			 eq.set_next_hp_event(30);
+			 eq.set_next_hp_event(30)
 		elseif PKK_hitpoints == 30 then
-			 eq.set_next_hp_event(10);
+			 eq.set_next_hp_event(10)
 		end
 	end
 end
 
 function PKK_Death(e)
-	eq.signal(298223, 298201); -- NPC: zone_status
-	eq.signal(298223,2,1000); -- Unlock Doors
+	eq.signal(298223, 298201) -- NPC: zone_status
+	eq.signal(298223,2,1000)  -- Unlock Doors
 end
 
 function PKK_Combat(e)
 	if e.joined then
-		e.self:Say("You shall regret trespassing into my chambers. The might of our kind shall smother the flames of life in this world, starting with you.");
-		e.self:Say("Do you really think your paltry skills will be enough to best a being as powerful as I? ");
-			if (e.self:GetHPRatio() < 92) then
-				eq.set_timer("check", 1 * 1000); -- set scorpion timer on future phases
+		e.self:Say("You shall regret trespassing into my chambers. The might of our kind shall smother the flames of life in this world, starting with you.")
+		e.self:Say("Do you really think your paltry skills will be enough to best a being as powerful as I? ")
+		if e.self:GetHPRatio() < 92 then
+				eq.set_timer("check", 1 * 1000) -- set scorpion timer on future phases
 			end
 	elseif not e.joined then
-		eq.set_timer("wipecheck", 5000);
-		eq.stop_timer("check");
+		eq.set_timer("wipecheck", 5000)
+		eq.stop_timer("check")
 	end
 end
 
 function PKK_Husk_Spawn(e)
-	eq.set_timer("wipecheck", 1500);
+	eq.set_timer("wipecheck", 1500)
 end
 
 function PKK_Timer(e)
-	if (e.timer == "wipecheck") then
+	if e.timer == "wipecheck" then
 		-- Check to see if there are any Clients in the room with PKK
-		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 5000);
+		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 5000)
 		if not client:IsClient() then
-			PKK_hitpoints = 100;
-			eq.depop_all(298203); -- Reflection 1
-			eq.depop_all(298204); -- Reflection 2
-			eq.depop_all(298046); -- Reflection 3
-			eq.depop_all(298146); -- Reflection 4
-			eq.depop_all(298048); -- Hatchling
-			eq.depop(); -- will depop either husk or PKK
-			eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378); -- NPC: Pixtt_Kretv_Krakxt
-			eq.signal(298223,2); -- Unlock Doors
+			PKK_hitpoints = 100
+			eq.depop_all(298203) -- Reflection 1
+			eq.depop_all(298204) -- Reflection 2
+			eq.depop_all(298046) -- Reflection 3
+			eq.depop_all(298146) -- Reflection 4
+			eq.depop_all(298048) -- Hatchling
+			eq.depop() -- will depop either husk or PKK
+			eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378) -- NPC: Pixtt_Kretv_Krakxt
+			eq.signal(298223,2) -- Unlock Doors
 		end
-	elseif (e.timer == "tenae") then
-		e.self:CastSpell(eq.ChooseRandom(889, 887, 751, 888),e.self:GetTarget():GetID());
-	elseif (e.timer == "check") then
-		local instance_id = eq.get_zone_instance_id();
+	elseif e.timer == "tenae" then
+		e.self:CastSpell(eq.ChooseRandom(889, 887, 751, 888),e.self:GetTarget():GetID())
+	elseif e.timer == "check" then
+		local instance_id = eq.get_zone_instance_id()
 		e.self:ForeachHateList(
 			function(ent, hate, damage, frenzy)
-				if(ent:IsClient() and ent:GetX() < 99 or ent:GetX() > 245 or ent:GetY() < 192 or ent:GetY() > 297) then
-					local currclient=ent:CastToClient();
+				if (ent:IsClient() and ent:GetX() < 99 or ent:GetX() > 245 or ent:GetY() < 192 or ent:GetY() > 297) then
+					local currclient=ent:CastToClient()
 					--e.self:Shout("You will not evade me " .. currclient:GetName())
-					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-					currclient:Message(MT.Magenta,"Pixtt Kretv Krakxt says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0) -- Zone: tacvi
+					currclient:Message(MT.Magenta,"Pixtt Kretv Krakxt says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.")
 				end
 			end
-		);
+		)
 	end
 end
 
 function Spawn_Hatchlings(number, x, y, z, h)
-	hatchlings_spawned = number;
-	hatchlings_killed = 0;
+	hatchlings_spawned = number
+	hatchlings_killed  = 0
+	eq.spawn2(298048,0,0,x+15, y+15, z, h) -- NPC: an_ikaav_hatchling
+	eq.spawn2(298048,0,0,x+15, y-15, z, h) -- NPC: an_ikaav_hatchling
+	eq.spawn2(298048,0,0,x-15, y-15, z, h) -- NPC: an_ikaav_hatchling
 
-	eq.spawn2(298048,0,0,x+15, y+15, z, h); -- NPC: an_ikaav_hatchling
-	eq.spawn2(298048,0,0,x+15, y-15, z, h); -- NPC: an_ikaav_hatchling
-	eq.spawn2(298048,0,0,x-15, y-15, z, h); -- NPC: an_ikaav_hatchling
-
-	if (number >= 4) then
-		eq.spawn2(298048,0,0,x-15, y+15, z, h); -- NPC: an_ikaav_hatchling
+	if number >= 4 then
+		eq.spawn2(298048,0,0,x-15, y+15, z, h) -- NPC: an_ikaav_hatchling
 	end
-	if (number >= 5) then
-		eq.spawn2(298048,0,0,x+7, y+15, z, h); -- NPC: an_ikaav_hatchling
+	if number >= 5 then
+		eq.spawn2(298048,0,0,x+7, y+15, z, h) -- NPC: an_ikaav_hatchling
 	end
-	if (number >= 6) then
-		eq.spawn2(298048,0,0,x+7, y+7, z, h); -- NPC: an_ikaav_hatchling
+	if number >= 6 then
+		eq.spawn2(298048,0,0,x+7, y+7, z, h) -- NPC: an_ikaav_hatchling
 	end
-	if (number >= 7) then
-		eq.spawn2(298048,0,0,x, y, z, h); -- NPC: an_ikaav_hatchling
+	if number >= 7 then
+		eq.spawn2(298048,0,0,x, y, z, h) -- NPC: an_ikaav_hatchling
 	end
 end
 
 function PKK_Hp(e)
-	PKK_hitpoints = e.hp_event;
-	if (e.hp_event == 90) then
-		eq.zone_emote(MT.Red,"Ha ha ha, you fools thought you could overpower me. You are nothing but food for my offspring. Come my children, strike them down and suck the marrow from their bones. Kretv's body falls to the ground -- a lifeless husk freeing the hatchlings within.");
-		eq.set_timer("check", 1 * 1000);
-		eq.signal(298223,1); -- Lock Doors
-		eq.depop();
-		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
-		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
-		Spawn_Hatchlings(4, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-	elseif (e.hp_event == 70) then
-		eq.zone_emote(MT.Red,"Your efforts shall fail no matter how great. This is a reality you shall soon see as your vile existence ceases and my brood consumes your remains.");
-		eq.depop();
-		Spawn_Hatchlings(5, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
-		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
-		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
-	elseif (e.hp_event == 50) then
-		eq.zone_emote(MT.Red,"You show surprising strength and conviction, but you will not get any further. The time has come for you to be destroyed.");
-		eq.depop();
-		Spawn_Hatchlings(6, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
-		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
-		eq.spawn2(298046, 95, 0, 116.0, 206.0, -7.0, 162); -- NPC: Reflection_of_Kretv_Krakxt
-		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
-	elseif (e.hp_event == 30) then
-		eq.zone_emote(MT.Red,"My resolve is waning but I shall fight you to the very last breath. The commander looks down upon weaklings in his ranks and the ikaav are not ones to indulge in it.");
-		eq.depop();
-		Spawn_Hatchlings(7, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3); -- husk
-		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332); -- reflection
-		eq.spawn2(298046, 95, 0, 116.0, 206.0, -7.0, 162); -- NPC: Reflection_of_Kretv_Krakxt
-		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0); -- needs_heading_validation
-		eq.spawn2(298146, 96, 0, 227.0, 284.0, -6.0, 315.0); -- needs_heading_validation
-	elseif (e.hp_event == 10) then
-		eq.zone_emote(MT.Red,"The end is inevitable, but if I must be defeated, some of you will join me in the afterlife.");
-		Spawn_Hatchlings(3, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1);
-		e.self:SetSpecialAbility(SpecialAbility.rampage, 0); -- turn off single rampage
-		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1); -- turn aoe ramp on
-		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 50); -- 50% mitigated aoe ramp dmg
-		e.self:CastSpell(eq.ChooseRandom(889, 887, 751, 888),e.self:GetTarget():GetID());
-		eq.set_timer("tenae", 12 * 1000);
+	PKK_hitpoints = e.hp_event
+	if e.hp_event == 90 then
+		eq.zone_emote(MT.Red,"Ha ha ha, you fools thought you could overpower me. You are nothing but food for my offspring. Come my children, strike them down and suck the marrow from their bones. Kretv's body falls to the ground -- a lifeless husk freeing the hatchlings within.")
+		eq.set_timer("check", 1 * 1000)
+		eq.signal(298223,1) -- Lock Doors
+		eq.depop()
+		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332) -- reflection
+		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3) -- husk
+		Spawn_Hatchlings(4, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1)
+	elseif e.hp_event == 70 then
+		eq.zone_emote(MT.Red,"Your efforts shall fail no matter how great. This is a reality you shall soon see as your vile existence ceases and my brood consumes your remains.")
+		eq.depop()
+		Spawn_Hatchlings(5, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1)
+		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3) -- husk
+		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332) -- reflection
+		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0) -- needs_heading_validation
+	elseif e.hp_event == 50 then
+		eq.zone_emote(MT.Red,"You show surprising strength and conviction, but you will not get any further. The time has come for you to be destroyed.")
+		eq.depop()
+		Spawn_Hatchlings(6, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1)
+		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3) -- husk
+		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332) -- reflection
+		eq.spawn2(298046, 95, 0, 116.0, 206.0, -7.0, 162) -- NPC: Reflection_of_Kretv_Krakxt
+		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0) -- needs_heading_validation
+	elseif e.hp_event == 30 then
+		eq.zone_emote(MT.Red,"My resolve is waning but I shall fight you to the very last breath. The commander looks down upon weaklings in his ranks and the ikaav are not ones to indulge in it.")
+		eq.depop()
+		Spawn_Hatchlings(7, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1)
+		eq.spawn2(298047, 0, 0, 161.0, 242.0, -7.0, 378):SetAppearance(3) -- husk
+		eq.spawn2(298204, 93, 0, 120.0, 279.0, -7.0, 332) -- reflection
+		eq.spawn2(298046, 95, 0, 116.0, 206.0, -7.0, 162) -- NPC: Reflection_of_Kretv_Krakxt
+		eq.spawn2(298203, 94, 0, 228.0, 221.0, -7.0, 427.0) -- needs_heading_validation
+		eq.spawn2(298146, 96, 0, 227.0, 284.0, -6.0, 315.0) -- needs_heading_validation
+	elseif e.hp_event == 10 then
+		eq.zone_emote(MT.Red,"The end is inevitable, but if I must be defeated, some of you will join me in the afterlife.")
+		Spawn_Hatchlings(3, e.self:GetX(), e.self:GetY(), e.self:GetZ(), 189.1)
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 0) -- turn off single rampage
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1) -- turn aoe ramp on
+		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 50) -- 50% mitigated aoe ramp dmg
+		e.self:CastSpell(eq.ChooseRandom(889, 887, 751, 888),e.self:GetTarget():GetID())
+		eq.set_timer("tenae", 12 * 1000)
 	end
 end
 
 function PKK_Hatchling_Death(e)
-	hatchlings_killed = hatchlings_killed + 1;
+	hatchlings_killed = hatchlings_killed + 1
 	-- the events at 10 don't want to do extra hatchling stuff
-	if ( hatchlings_killed >= hatchlings_spawned and PKK_hitpoints ~= 10 ) then
-		eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378); -- NPC: Pixtt_Kretv_Krakxt
-		eq.signal(298203, 1); -- NPC: Reflection_of_Kretv_Krakxt
-		eq.signal(298204, 1); -- NPC: Reflection_of_Kretv_Krakxt
-		eq.signal(298203, 1); -- NPC: Reflection_of_Kretv_Krakxt
-		eq.signal(298046, 1); -- NPC: Reflection_of_Kretv_Krakxt
-		eq.signal(298146, 1); -- NPC: Reflection_of_Kretv_Krakxt
+	if hatchlings_killed >= hatchlings_spawned and PKK_hitpoints ~= 10 then
+		eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378) -- NPC: Pixtt_Kretv_Krakxt
+		eq.signal(298203, 1) -- NPC: Reflection_of_Kretv_Krakxt
+		eq.signal(298204, 1) -- NPC: Reflection_of_Kretv_Krakxt
+		eq.signal(298203, 1) -- NPC: Reflection_of_Kretv_Krakxt
+		eq.signal(298046, 1) -- NPC: Reflection_of_Kretv_Krakxt
+		eq.signal(298146, 1) -- NPC: Reflection_of_Kretv_Krakxt
 	end
-	e.self:Emote("black blood spills on the floor");
+	e.self:Emote("black blood spills on the floor")
 end
 
 function PKK_Hatchling_Spawn(e)
-	e.self:ModSkillDmgTaken(3, -20); -- 2h slashing
-	e.self:ModSkillDmgTaken(1, -20); -- 1h slashing
-	e.self:ModSkillDmgTaken(7, 10); -- archery
+	e.self:ModSkillDmgTaken(3, -20) -- 2h slashing
+	e.self:ModSkillDmgTaken(1, -20) -- 1h slashing
+	e.self:ModSkillDmgTaken(7, 10) -- archery
 end
 
 function PKK_Roaming_Caster_One_Spawn(e)
-	eq.start(93);
-	CastOnRandom(e.self, 889); -- Delusional Visions
-	eq.set_timer('snake1', 30000);
+	eq.start(93)
+	CastOnRandom(e.self, 889) -- Delusional Visions
+	eq.set_timer('snake1', 30000)
 end
 
 function PKK_Roaming_Caster_Two_Spawn(e)
-	eq.start(94);
-	CastOnRandom(e.self, 887); -- Aura of Fatigue
-	eq.set_timer('snake1', 30000);
+	eq.start(94)
+	CastOnRandom(e.self, 887) -- Aura of Fatigue
+	eq.set_timer('snake1', 30000)
 end
 
 function PKK_Roaming_Caster_Three_Spawn(e)
-	eq.start(95);
-	CastOnRandom(e.self, 751); -- Ikaav's Venom
-	eq.set_timer('snake1', 30000);
+	eq.start(95)
+	CastOnRandom(e.self, 751) -- Ikaav's Venom
+	eq.set_timer('snake1', 30000)
 end
 
 function PKK_Roaming_Caster_Four_Spawn(e)
-	eq.start(96);
-	CastOnRandom(e.self, 888); -- Wrath of the Ikaav
-	eq.set_timer('snake1', 30000);
+	eq.start(96)
+	CastOnRandom(e.self, 888) -- Wrath of the Ikaav
+	eq.set_timer('snake1', 30000)
 end
 
 function CastOnRandom(caster, spell)
-	local client = eq.get_entity_list():GetRandomClient(162, 241, -7, 5000);
-	caster:DoAnim(44);
-
-	caster:CastSpell(spell, client:GetID());
+	local client = eq.get_entity_list():GetRandomClient(162, 241, -7, 5000)
+	caster:DoAnim(44)
+	caster:CastSpell(spell, client:GetID())
 end
 
 function PKK_Roaming_Caster_One_Timer(e)
-	CastOnRandom(e.self, 889); -- Delusional Visions
+	CastOnRandom(e.self, 889) -- Delusional Visions
 end
 
 function PKK_Roaming_Caster_Two_Timer(e)
-	CastOnRandom(e.self, 887); -- Aura of Fatigue
+	CastOnRandom(e.self, 887) -- Aura of Fatigue
 end
 
 function PKK_Roaming_Caster_Three_Timer(e)
-	CastOnRandom(e.self, 751); -- Ikaav's Venom
+	CastOnRandom(e.self, 751) -- Ikaav's Venom
 end
 
 function PKK_Roaming_Caster_Four_Timer(e)
-	CastOnRandom(e.self, 888); -- Wrath of the Ikaav
+	CastOnRandom(e.self, 888) -- Wrath of the Ikaav
 end
 
 function PKK_Roaming_Caster_Signal(e)
-	eq.depop();
+	eq.depop()
 end
 
 function event_encounter_load(e)
-	eq.register_npc_event('pkk', Event.spawn,          298201, PKK_Spawn);
-	eq.register_npc_event('pkk', Event.combat,         298201, PKK_Combat);
-	eq.register_npc_event('pkk', Event.hp,             298201, PKK_Hp);
-	eq.register_npc_event('pkk', Event.timer,          298201, PKK_Timer);
-	eq.register_npc_event('pkk', Event.death_complete, 298201, PKK_Death);
+	eq.register_npc_event('pkk', Event.spawn,          298201, PKK_Spawn)
+	eq.register_npc_event('pkk', Event.combat,         298201, PKK_Combat)
+	eq.register_npc_event('pkk', Event.hp,             298201, PKK_Hp)
+	eq.register_npc_event('pkk', Event.timer,          298201, PKK_Timer)
+	eq.register_npc_event('pkk', Event.death_complete, 298201, PKK_Death)
 
-	eq.register_npc_event('pkk', Event.death_complete, 298048, PKK_Hatchling_Death);
-	eq.register_npc_event('pkk', Event.spawn, 298048, PKK_Hatchling_Spawn);
+	eq.register_npc_event('pkk', Event.death_complete, 298048, PKK_Hatchling_Death)
+	eq.register_npc_event('pkk', Event.spawn, 298048, PKK_Hatchling_Spawn)
 
-	eq.register_npc_event('pkk', Event.spawn,          298047, PKK_Husk_Spawn);
-	eq.register_npc_event('pkk', Event.timer,          298047, PKK_Timer); -- Reusing PKK Timer function, should be safe
+	eq.register_npc_event('pkk', Event.spawn,          298047, PKK_Husk_Spawn)
+	eq.register_npc_event('pkk', Event.timer,          298047, PKK_Timer) -- Reusing PKK Timer function, should be safe
 
-	eq.register_npc_event('pkk', Event.spawn,          298204, PKK_Roaming_Caster_One_Spawn);
-	eq.register_npc_event('pkk', Event.timer,          298204, PKK_Roaming_Caster_One_Timer);
-	eq.register_npc_event('pkk', Event.signal,         298204, PKK_Roaming_Caster_Signal);
+	eq.register_npc_event('pkk', Event.spawn,          298204, PKK_Roaming_Caster_One_Spawn)
+	eq.register_npc_event('pkk', Event.timer,          298204, PKK_Roaming_Caster_One_Timer)
+	eq.register_npc_event('pkk', Event.signal,         298204, PKK_Roaming_Caster_Signal)
 
-	eq.register_npc_event('pkk', Event.spawn,          298203, PKK_Roaming_Caster_Two_Spawn);
-	eq.register_npc_event('pkk', Event.timer,          298203, PKK_Roaming_Caster_Two_Timer);
-	eq.register_npc_event('pkk', Event.signal,         298203, PKK_Roaming_Caster_Signal);
+	eq.register_npc_event('pkk', Event.spawn,          298203, PKK_Roaming_Caster_Two_Spawn)
+	eq.register_npc_event('pkk', Event.timer,          298203, PKK_Roaming_Caster_Two_Timer)
+	eq.register_npc_event('pkk', Event.signal,         298203, PKK_Roaming_Caster_Signal)
 
-	eq.register_npc_event('pkk', Event.spawn,          298046, PKK_Roaming_Caster_Three_Spawn);
-	eq.register_npc_event('pkk', Event.timer,          298046, PKK_Roaming_Caster_Three_Timer);
-	eq.register_npc_event('pkk', Event.signal,         298046, PKK_Roaming_Caster_Signal);
+	eq.register_npc_event('pkk', Event.spawn,          298046, PKK_Roaming_Caster_Three_Spawn)
+	eq.register_npc_event('pkk', Event.timer,          298046, PKK_Roaming_Caster_Three_Timer)
+	eq.register_npc_event('pkk', Event.signal,         298046, PKK_Roaming_Caster_Signal)
 
-	eq.register_npc_event('pkk', Event.spawn,          298146, PKK_Roaming_Caster_Four_Spawn);
-	eq.register_npc_event('pkk', Event.timer,          298146, PKK_Roaming_Caster_Four_Timer);
-	eq.register_npc_event('pkk', Event.signal,         298146, PKK_Roaming_Caster_Signal);
+	eq.register_npc_event('pkk', Event.spawn,          298146, PKK_Roaming_Caster_Four_Spawn)
+	eq.register_npc_event('pkk', Event.timer,          298146, PKK_Roaming_Caster_Four_Timer)
+	eq.register_npc_event('pkk', Event.signal,         298146, PKK_Roaming_Caster_Signal)
 end

--- a/tacvi/encounters/prt.lua
+++ b/tacvi/encounters/prt.lua
@@ -1,71 +1,74 @@
-local construct = 0;
-local golems_spawn = false;
+local construct    = 0
+local golems_spawn = false
 
 function PRT_Spawn(e)
-	e.self:ModSkillDmgTaken(1, -30); -- 1h slashing
-	e.self:ModSkillDmgTaken(3, -30); -- 2h slashing
-	e.self:ModSkillDmgTaken(7, -25); -- archery
-	--spawn the two starting golems
-	eq.unique_spawn(298002, 0, 0, 229.0, -572.0, -3.25, 384):SetAppearance(3); -- NPC: a_corrupted_construct (ramp)
-	eq.unique_spawn(298026, 0, 0, 225.0, -600.0, -3.25, 410):SetAppearance(3); -- NPC: a_corrupted_construct (flurry)
+	e.self:ModSkillDmgTaken(1, -30) -- 1h slashing
+	e.self:ModSkillDmgTaken(3, -30) -- 2h slashing
+	e.self:ModSkillDmgTaken(7, -25) -- archery
+	-- spawn the two starting golems
+	eq.unique_spawn(298002, 0, 0, 229.0, -572.0, -3.25, 384):SetAppearance(3) -- NPC: a_corrupted_construct (ramp)
+	eq.unique_spawn(298026, 0, 0, 225.0, -600.0, -3.25, 410):SetAppearance(3) -- NPC: a_corrupted_construct (flurry)
 
-	eq.set_next_hp_event(90)
-	golems_spawn = false;
-	construct = 0;
+	e.self:SetSpecialAbility(SpecialAbility.summon, 0) -- No Summon
+	eq.set_next_hp_event(98)
+	golems_spawn = false
+	construct = 0
 end
 
 function PRT_Combat(e)
 	if e.joined then
 		e.self:Say("You shall regret trespassing into my chambers. Rise my minions and show them how well I have learned to use the power of this land's creatures. Destroy them all. Leave only enough to feed the hounds")
-		eq.stop_timer('wipecheck');
-		
-		eq.signal(298002,1); --a_corrupted_construct remove immunities
-		eq.signal(298026,1); --a_corrupted_construct remove immunities
-		
+		eq.stop_timer('wipecheck')
+
+		eq.signal(298002,1) --a_corrupted_construct remove immunities
+		eq.signal(298026,1) --a_corrupted_construct remove immunities
+
 		if golems_spawn then
-			eq.set_timer("SpawnGolem", 6 * 1000);
+			eq.set_timer("SpawnGolem", 6 * 1000)
 		end
 	else
 		-- Wipe stuff
-	
-		eq.signal(298002,2); --a_corrupted_construct add immunities
-		eq.signal(298026,2); --a_corrupted_construct add immunities
-		
-		eq.set_timer('wipecheck', 30 * 1000);
-		eq.stop_timer("SpawnGolem");
-		eq.stop_timer('VenomAE');
-		eq.stop_timer('Delusional');
+		eq.signal(298002,2) --a_corrupted_construct add immunities
+		eq.signal(298026,2) --a_corrupted_construct add immunities
+
+		eq.set_timer('wipecheck', 30 * 1000)
+		eq.stop_timer("SpawnGolem")
+		eq.stop_timer('VenomAE')
+		eq.stop_timer('Delusional')
 	end
 end
 
 function PRT_HP(e)
-	if (e.hp_event == 90) then
-		--lock door behind her
-		eq.signal(298223,1); -- Lock Doors
+	if e.hp_event == 98 then
+		e.self:SetSpecialAbility(SpecialAbility.summon, 1)
+		eq.set_next_hp_event(90)
+	elseif e.hp_event == 90 then
+		-- lock door behind her
+		eq.signal(298223,1) -- Lock Doors
 		eq.set_next_hp_event(50)
-		eq.set_timer("check", 1 * 1000); -- start checking for clients outside room
-		eq.zone_emote(MT.White,"Riel raises her hands to the sky and laughs as the door behind you seals itself.");
-	elseif (e.hp_event == 50) then
+		eq.set_timer("check", 1 * 1000) -- start checking for clients outside room
+		eq.zone_emote(MT.White,"Riel raises her hands to the sky and laughs as the door behind you seals itself.")
+	elseif e.hp_event == 50 then
 		--add flurry, reduce atk delay
-		e.self:ModifyNPCStat("attack_delay","12");
+		e.self:ModifyNPCStat("attack_delay","12")
 		e.self:SetSpecialAbility(SpecialAbility.flurry, 1)
 		eq.set_timer("Delusional", 30 * 1000)
 		e.self:Say("So it seems you are not so easily defeated after all. I am through toying with you fools. Prepare for the reality of death.' Riel's body begins to speed up as her attacks become increasingly vicious")
 		eq.set_next_hp_event(30)
-	elseif (e.hp_event == 30) then
-		--start golem waves, first spawn is 4, next are based on hp (4 <=30%, 8 <=20%, 12 <=10%)
+	elseif e.hp_event == 30 then
+		-- start golem waves, first spawn is 4, next are based on hp (4 <=30%, 8 <=20%, 12 <=10%)
 		eq.set_timer("SpawnGolem", 6 * 1000)
-		e.self:Say("You and your friends are starting to annoy me.  Come forth my little experiments.  Choose one of these fools and show them the surprise you have waiting.");
-		--spawn 4 mini golems
-		--an_unstable_construct (298045)
+		e.self:Say("You and your friends are starting to annoy me.  Come forth my little experiments.  Choose one of these fools and show them the surprise you have waiting.")
+		-- spawn 4 mini golems
+		-- an_unstable_construct (298045)
 		eq.set_next_hp_event(25)
-		golems_spawn = true;
-	elseif (e.hp_event == 25) then
+		golems_spawn = true
+	elseif e.hp_event == 25 then
 		--add Ikaav's Venom AE
-		eq.set_timer("VenomAE", 30000)
+		eq.set_timer("VenomAE", 30 * 1000)
 		e.self:CastSpell(751,e.self:GetID())
 		eq.set_next_hp_event(10)
-	elseif (e.hp_event == 10) then
+	elseif e.hp_event == 10 then
 		-- At approximately 10% health, she increases her attack speed and begins flurrying much more (every round)
 		e.self:SetSpecialAbilityParam(SpecialAbility.flurry, 0, 100)
 		e.self:Say("That's it!  You have past the point of being bothersome. I grow weary of this encounter. It is time for it to end.")
@@ -73,94 +76,92 @@ function PRT_HP(e)
 end
 
 function PRT_Timer(e)
-	if (e.timer == "Delusional") then
-		--Delusional Vision single target DD/Drunk whole fight
-		e.self:SpellFinished(889, e.self:GetHateTop()) --CastToClient? --no need unless using client-based methods
-	elseif (e.timer == "VenomAE") then
-		--Ikaav's Venom 751
+	if e.timer == "Delusional" then
+		-- Delusional Vision single target DD/Drunk whole fight
+		e.self:SpellFinished(889, e.self:GetHateTop()) -- CastToClient? --no need unless using client-based methods
+	elseif e.timer == "VenomAE" then
+		-- Ikaav's Venom 751
 		e.self:CastSpell(751,e.self:GetID())
-	elseif(e.timer=="SpawnGolem") then
-		local construct_locs = { 
-			[1] = { 189.61, -586.55, -8.55,128}, 
+	elseif e.timer == "SpawnGolem" then
+		local construct_locs = {
+			[1] = { 189.61, -586.55, -8.55,128},
 			[2] = { 180.10, -569.03, -8.55,380},
-			[3] = { 180.10, -609.61, -8.55,128}, 
+			[3] = { 180.10, -609.61, -8.55,128},
 			[4] = { 107.81, -586.55, -8.55,128}
-		};
-		--eq.stop_timer("SpawnGolem");
-		if (e.self:GetHPRatio() >= 20) then
-			if ( construct < 12 ) then	
-				local rng = math.random(4, 4);
-				local spawned = 0;
+		}
+
+		if e.self:GetHPRatio() >= 20 then
+			if construct < 12 then
+				local rng = math.random(4, 4)
+				local spawned = 0
 
 				for i = construct+1, 12 do
-					local ran = math.random(1,4);
-					eq.spawn2(298045, 0, 0, unpack(construct_locs[ran]));
-					spawned = spawned + 1;
-					if ( spawned == rng ) then
+					local ran = math.random(1,4)
+					eq.spawn2(298045, 0, 0, unpack(construct_locs[ran]))
+					spawned = spawned + 1
+					if spawned == rng then
 						break;
 					end
 				end
-				construct = construct + spawned;
+				construct = construct + spawned
 			end
-		elseif (e.self:GetHPRatio() > 10 and e.self:GetHPRatio() < 20) then
-			if ( construct < 12 ) then	
-				local rng = math.random(8, 8);
-				local spawned = 0;
+		elseif e.self:GetHPRatio() > 10 and e.self:GetHPRatio() < 20 then
+			if construct < 12 then
+				local rng = math.random(8, 8)
+				local spawned = 0
 	
 				for i = construct+1, 12 do
-					local ran = math.random(1,4);
-					eq.spawn2(298045, 0, 0, unpack(construct_locs[ran]));
-					spawned = spawned + 1;
-					if ( spawned == rng ) then
-						break;
+					local ran = math.random(1,4)
+					eq.spawn2(298045, 0, 0, unpack(construct_locs[ran]))
+					spawned = spawned + 1
+					if spawned == rng then
+						break
 					end
 				end
-				construct = construct + spawned;
+				construct = construct + spawned
 			end
-			eq.set_timer("SpawnGolem", 4 * 1000) --speed up timer
-		elseif (e.self:GetHPRatio() < 10) then
-			if ( construct < 12 ) then		
-				local rng = math.random(12, 12);
-				local spawned = 0;
+			eq.set_timer("SpawnGolem", 4 * 1000) -- speed up timer
+		elseif e.self:GetHPRatio() < 10 then
+			if construct < 12 then
+				local rng = math.random(12, 12)
+				local spawned = 0
 	
 				for i = construct+1, 12 do
-					local ran = math.random(1,4);
-					eq.spawn2(298045, 0, 0, unpack(construct_locs[ran]));
-					spawned = spawned + 1;
-					if ( spawned == rng ) then
-						break;
+					local ran = math.random(1,4)
+					eq.spawn2(298045, 0, 0, unpack(construct_locs[ran]))
+					spawned = spawned + 1
+					if spawned == rng then
+						break
 					end
 				end
-				construct = construct + spawned;
+				construct = construct + spawned
 			end
-			eq.set_timer("SpawnGolem", 2 * 1000) --speed up timer
+			eq.set_timer("SpawnGolem", 2 * 1000) -- speed up timer
 		end
-	elseif (e.timer == 'wipecheck') then
-		--eq.depop_all(298045);
-		--eq.depop_all(298002);
-		--eq.depop();
-		--eq.spawn2(298032, 0, 0, 202.0, -586.0, -4.125, 380); -- NPC: Pixtt_Riel_Tavas
-		eq.stop_timer('wipecheck');
+	elseif e.timer == 'wipecheck' then
+		eq.stop_timer('wipecheck')
 		e.self:SetHP(e.self:GetMaxHP())
-		eq.unique_spawn(298002, 0, 0, 229.0, -572.0, -3.25, 384):SetAppearance(3); -- NPC: a_corrupted_construct (ramp)
-		eq.unique_spawn(298026, 0, 0, 225.0, -600.0, -3.25, 410):SetAppearance(3); -- NPC: a_corrupted_construct (flurry)
-		eq.depop_all(298045);
-		eq.set_next_hp_event(90)
-		golems_spawn = false;
-		construct = 0;		
-		eq.signal(298223,2); -- Unlock Doors
-	elseif (e.timer == "check") then
-		local instance_id = eq.get_zone_instance_id();
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 0)
+		e.self:SetSpecialAbility(SpecialAbility.summon, 0) -- No Summon
+		e.self:ModifyNPCStat("attack_delay","16")
+		eq.unique_spawn(298002, 0, 0, 229.0, -572.0, -3.25, 384):SetAppearance(3) -- NPC: a_corrupted_construct (ramp)
+		eq.unique_spawn(298026, 0, 0, 225.0, -600.0, -3.25, 410):SetAppearance(3) -- NPC: a_corrupted_construct (flurry)
+		eq.depop_all(298045)
+		eq.set_next_hp_event(98)
+		golems_spawn = false
+		construct = 0	
+		eq.signal(298223,2) -- Unlock Doors
+	elseif e.timer == "check" then
+		local instance_id = eq.get_zone_instance_id()
 		e.self:ForeachHateList(
 			function(ent, hate, damage, frenzy)
-				if(ent:IsClient() and ent:GetX() < 100 or ent:GetX() > 244 or ent:GetY() > -535 or ent:GetY() < -636) then
-					local currclient=ent:CastToClient();
-					--e.self:Shout("You will not evade me " .. currclient:GetName())
-					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-					currclient:Message(MT.Magenta,"Pixtt Riel Tavas says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+				if (ent:IsClient() and ent:GetX() < 100 or ent:GetX() > 244 or ent:GetY() > -535 or ent:GetY() < -636) then
+					local currclient=ent:CastToClient()
+					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0) -- Zone: tacvi
+					currclient:Message(MT.Magenta,"Pixtt Riel Tavas says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.")
 				end
 			end
-		);
+		)
 	end
 end
 
@@ -169,13 +170,13 @@ function PRT_Death(e)
 	eq.zone_emote(MT.Yellow, "With the death of the great beast, the seals on the doors fade away. Your path is now clear.")
 
 	-- Open doors
-	eq.signal(298223, 298032); -- NPC: zone_status
-	eq.signal(298223,2,1000); -- Unlock Doors
+	eq.signal(298223, 298032) -- NPC: zone_status
+	eq.signal(298223,2,1000)  -- Unlock Doors
 end
 
 function PRT_Signal(e)
-	if (e.signal == 1) then
-		construct = construct - 1; --add dead or mez death
+	if e.signal == 1 then
+		construct = construct - 1 -- add dead or mez death
 	end
 end
 
@@ -183,11 +184,11 @@ end
 -- Big golem at beginning of Pixtt_Riel_Tavas fight
 function Corrupt_Spawn(e)
 	e.self:SetAppearance(3)
-	e.self:ModSkillDmgTaken(1, -25); -- 1h slashing
-	e.self:ModSkillDmgTaken(3, -25); -- 2h slashing
-	e.self:ModSkillDmgTaken(0, 10); -- 1h blunt
-	e.self:ModSkillDmgTaken(2, 10); -- 2h blunt
-	e.self:ModSkillDmgTaken(7, -25); -- archery
+	e.self:ModSkillDmgTaken(1, -25) -- 1h slashing
+	e.self:ModSkillDmgTaken(3, -25) -- 2h slashing
+	e.self:ModSkillDmgTaken(0, 10)  -- 1h blunt
+	e.self:ModSkillDmgTaken(2, 10)  -- 2h blunt
+	e.self:ModSkillDmgTaken(7, -25) -- archery
 end
 
 function Corrupt_Death(e)
@@ -195,13 +196,13 @@ function Corrupt_Death(e)
 end
 
 function Corrupt_Signal(e)
-	if (e.signal == 1) then
-		e.self:SetSpecialAbility(35, 0); --turn off immunity
-		e.self:SetSpecialAbility(24, 0); --turn off anti aggro
-	elseif (e.signal == 2) then
-		e.self:SetSpecialAbility(35, 1); --turn on immunity
-		e.self:SetSpecialAbility(24, 1); --turn on anti aggro
-		e.self:WipeHateList();
+	if e.signal == 1 then
+		e.self:SetSpecialAbility(35, 0) -- turn off immunity
+		e.self:SetSpecialAbility(24, 0) -- turn off anti aggro
+	elseif e.signal == 2 then
+		e.self:SetSpecialAbility(35, 1) -- turn on immunity
+		e.self:SetSpecialAbility(24, 1) -- turn on anti aggro
+		e.self:WipeHateList()
 	end
 end
 
@@ -209,46 +210,46 @@ end
 -- add during Pixtt_Riel_Tavas fight
 -- mini golems that cast a AE DD when they die
 function Unstable_Death(e)
-	eq.signal(298032,1); --Pixtt_Riel_Tavas (298032) signal to reduce add count	
-	e.self:CastSpell(4661, e.self:GetID()); -- Spell: Cataclysm of Stone
+	eq.signal(298032,1) -- Pixtt_Riel_Tavas (298032) signal to reduce add count	
+	e.self:CastSpell(4661, e.self:GetID()) -- Spell: Cataclysm of Stone
 end
 
 function Unstable_Spawn(e)
-	eq.set_timer("mez_check", 1 * 1000); -- 1s check
+	eq.set_timer("mez_check", 1 * 1000) -- 1s check
 end
 
 function Unstable_Timer(e)
 	if e.timer == "mez_check" then
 		if e.self:IsMezzed() then
-			eq.stop_timer("mez_check");
-			eq.set_timer("depop", 30 * 1000); -- depop in 30s
+			eq.stop_timer("mez_check")
+			eq.set_timer("depop", 30 * 1000) -- depop in 30s
 		end
 	elseif e.timer == "depop" then
-		eq.stop_timer("depop");
+		eq.stop_timer("depop")
 		if eq.get_entity_list():IsMobSpawnedByNpcTypeID(298032) then -- only depops if PRT is alive
-			eq.signal(298032,1); --Pixtt_Riel_Tavas (298032) signal to reduce add count
-			e.self:Emote("ceases its struggles as the energy that brought it to life fades away.");			
-			eq.depop();
+			eq.signal(298032,1) -- Pixtt_Riel_Tavas (298032) signal to reduce add count
+			e.self:Emote("ceases its struggles as the energy that brought it to life fades away.")
+			eq.depop()
 		end
 	end
 end
 
 function event_encounter_load(e)
-	eq.register_npc_event('prt', Event.spawn,           298032, PRT_Spawn);
-	eq.register_npc_event('prt', Event.combat,          298032, PRT_Combat);
-	eq.register_npc_event('prt', Event.hp,              298032, PRT_HP);
-	eq.register_npc_event('prt', Event.timer,           298032, PRT_Timer);
-	eq.register_npc_event('prt', Event.death_complete,  298032, PRT_Death);
-	eq.register_npc_event('prt', Event.signal,           298032, PRT_Signal);
+	eq.register_npc_event('prt', Event.spawn,           298032, PRT_Spawn)
+	eq.register_npc_event('prt', Event.combat,          298032, PRT_Combat)
+	eq.register_npc_event('prt', Event.hp,              298032, PRT_HP)
+	eq.register_npc_event('prt', Event.timer,           298032, PRT_Timer)
+	eq.register_npc_event('prt', Event.death_complete,  298032, PRT_Death)
+	eq.register_npc_event('prt', Event.signal,           298032, PRT_Signal)
 
-	eq.register_npc_event('prt', Event.spawn,           298002, Corrupt_Spawn);
-	eq.register_npc_event('prt', Event.death_complete,  298002, Corrupt_Death);
-	eq.register_npc_event('prt', Event.spawn,           298026, Corrupt_Spawn);
-	eq.register_npc_event('prt', Event.death_complete,  298026, Corrupt_Death);
-	eq.register_npc_event('prt', Event.signal,           298002, Corrupt_Signal);
-	eq.register_npc_event('prt', Event.signal,           298026, Corrupt_Signal);
-	
-	eq.register_npc_event('prt', Event.death,           298045, Unstable_Death);
-	eq.register_npc_event('prt', Event.spawn,           298045, Unstable_Spawn);
-	eq.register_npc_event('prt', Event.timer,           298045, Unstable_Timer);
+	eq.register_npc_event('prt', Event.spawn,           298002, Corrupt_Spawn)
+	eq.register_npc_event('prt', Event.death_complete,  298002, Corrupt_Death)
+	eq.register_npc_event('prt', Event.spawn,           298026, Corrupt_Spawn)
+	eq.register_npc_event('prt', Event.death_complete,  298026, Corrupt_Death)
+	eq.register_npc_event('prt', Event.signal,           298002, Corrupt_Signal)
+	eq.register_npc_event('prt', Event.signal,           298026, Corrupt_Signal)
+
+	eq.register_npc_event('prt', Event.death,           298045, Unstable_Death)
+	eq.register_npc_event('prt', Event.spawn,           298045, Unstable_Spawn)
+	eq.register_npc_event('prt', Event.timer,           298045, Unstable_Timer)
 end

--- a/tacvi/encounters/pxk.lua
+++ b/tacvi/encounters/pxk.lua
@@ -1,178 +1,178 @@
-local entity_list = eq.get_entity_list();
-local juxtapincer = 4;
-local lifebleeder = 4;
-local manasipper  = 4;
-local ragehound   = 4;
+local juxtapincer = 4
+local lifebleeder = 4
+local manasipper  = 4
+local ragehound   = 4
 
 function PXK_Spawn(e)
-	e.self:SetPseudoRoot(true);
-	eq.set_next_hp_event(90);
-	eq.signal(298223,2);
+	e.self:SetPseudoRoot(true)
+	eq.set_next_hp_event(90)
+	eq.signal(298223,2)
 end
 
 function PXK_Death(e)
-	eq.signal(298223, 298039); -- NPC: zone_status
-	eq.signal(298223,2,1000); -- Unlock Doors
+	eq.signal(298223, 298039) -- NPC: zone_status
+	eq.signal(298223,2,1000)  -- Unlock Doors
 end
 
 function PXK_Combat(e)
 	if e.joined then
-		e.self:Say("Have at you intruder. This is the domain of the commander and only those strong enough to beat me shall pass.");
-	else 
+		e.self:Say("Have at you intruder. This is the domain of the commander and only those strong enough to beat me shall pass.")
+	else
 		-- Wipe mechanics
 		-- Depop adds, repop myself
-		eq.stop_timer("cleaver");
-		eq.stop_timer("rage");
-		eq.stop_timer("check");
-		eq.depop_all(298044);
-		eq.depop_all(298043);
-		eq.depop_all(298042);
-		eq.depop_all(298041);
-		eq.spawn2(298039,0,0,151,-162,-6,385); -- NPC: Pixtt_Xxeric_Kex
-		eq.depop();
+		eq.stop_timer("cleaver")
+		eq.stop_timer("rage")
+		eq.stop_timer("check")
+		eq.depop_all(298044)
+		eq.depop_all(298043)
+		eq.depop_all(298042)
+		eq.depop_all(298041)
+		eq.spawn2(298039,0,0,151,-162,-6,385) -- NPC: Pixtt_Xxeric_Kex
+		eq.depop()
 
 		-- reset the pet event counters in case of a wipe.
-		juxtapincer = 0;
-		lifebleeder = 0;
-		manasipper  = 0;
-		ragehound   = 0;
+		juxtapincer = 1
+		lifebleeder = 1
+		manasipper  = 1
+		ragehound   = 1
 
-		eq.signal(298223,2); -- Unlock Doors
+		eq.signal(298223,2) -- Unlock Doors
 	end
 end
 
 function PXK_Hp(e)
-	--90pct unroot
+	-- 90pct unroot
 	if e.hp_event == 90 then
-		--locks door leading into her chamber
-		eq.signal(298223,1); -- Lock Doors
-		eq.zone_emote(MT.Red,"Xxeric begins to froth at the mouth as her skin becomes more rigid and her rage begins to grow. You feel a force from behind you as the door is once again sealed.");
-		e.self:SetPseudoRoot(false);
-		e.self:CastedSpellFinished(4729, e.self:GetHateRandom()); -- Spell: Spirit Cleaver
-		eq.set_timer("cleaver", 120 * 1000);
-		eq.set_timer("check", 1 * 1000);
-		eq.modify_npc_stat("ac", "1150");
-		eq.modify_npc_stat("min_hit", "595");
-		eq.modify_npc_stat("max_hit", "4500");
-		eq.set_next_hp_event(70);
-		juxtapincer = 0;
-		lifebleeder = 0;
-		manasipper  = 0;
-		ragehound   = 0;
+		-- locks door leading into her chamber
+		eq.signal(298223,1) -- Lock Doors
+		eq.zone_emote(MT.Red,"Xxeric begins to froth at the mouth as her skin becomes more rigid and her rage begins to grow. You feel a force from behind you as the door is once again sealed.")
+		e.self:SetPseudoRoot(false)
+		e.self:CastedSpellFinished(4729, e.self:GetHateRandom()) -- Spell: Spirit Cleaver
+		eq.set_timer("cleaver", 120 * 1000)
+		eq.set_timer("check", 1 * 1000)
+		eq.modify_npc_stat("ac", "1150")
+		eq.modify_npc_stat("min_hit", "595")
+		eq.modify_npc_stat("max_hit", "4500")
+		eq.set_next_hp_event(70)
+		juxtapincer = 1
+		lifebleeder = 1
+		manasipper  = 1
+		ragehound   = 1
 	elseif e.hp_event == 70 then
-		eq.zone_emote(MT.Red,"The froth around her mouth thickens as she channels the force of her growing rage into each attack, sacrificing her thickened skin.");
-		eq.modify_npc_stat("ac", "604");
-		eq.modify_npc_stat("min_hit", "1300");
-		eq.modify_npc_stat("max_hit", "5945");
-		e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
-		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
-		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 85); -- 15 % mitigated dmg
-		eq.set_timer("cleaver", 90 * 1000);
-		eq.set_next_hp_event(50);
+		eq.zone_emote(MT.Red,"The froth around her mouth thickens as she channels the force of her growing rage into each attack, sacrificing her thickened skin.")
+		eq.modify_npc_stat("ac", "604")
+		eq.modify_npc_stat("min_hit", "1300")
+		eq.modify_npc_stat("max_hit", "5945")
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 0)
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1)
+		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 15) -- 15 % mitigated dmg
+
+		eq.set_timer("cleaver", 90 * 1000)
+		eq.set_next_hp_event(50)
 	elseif e.hp_event == 50 then
-		eq.zone_emote(MT.Red,"Raising her head to the sky, Xxeric lets out a battle cry that shakes the walls and calls forth a pack of raging ukun hounds. 'Prepare yourself for the afterlife this is the reality of the Mata Muram army.");
+		eq.zone_emote(MT.Red,"Raising her head to the sky, Xxeric lets out a battle cry that shakes the walls and calls forth a pack of raging ukun hounds. 'Prepare yourself for the afterlife this is the reality of the Mata Muram army.")
 		-- she begins casting  Wave of Rage
-		e.self:CastedSpellFinished(4728, e.self:GetHateRandom()); -- Spell: Wave of Rage
-		eq.set_timer("cleaver", 60 * 1000);
-		eq.set_timer("rage", 60 * 1000);
-		eq.modify_npc_stat("ac", "900");
+		e.self:CastedSpellFinished(4728, e.self:GetHateRandom()) -- Spell: Wave of Rage
+		eq.set_timer("cleaver", 60 * 1000)
+		eq.set_timer("rage", 60 * 1000)
+		eq.modify_npc_stat("ac", "900")
 		-- Spawn the Pets
-		eq.spawn2(298044,0,0, 151, -113, -6.87, 314); -- NPC: an_ukun_juxtapincer
-		eq.spawn2(298043,0,0, 151, -218, -6.87, 450); -- NPC: an_ukun_lifebleeder
-		eq.spawn2(298042,0,0,  81, -113, -6.87,  194); -- NPC: an_ukun_manasipper
-		eq.spawn2(298041,0,0,  81, -218, -6.87,  40); -- NPC: an_ukun_ragehound
-		eq.set_next_hp_event(30);
+		eq.spawn2(298044,0,0, 151, -113, -6.87, 314)  -- NPC: an_ukun_juxtapincer
+		eq.spawn2(298043,0,0, 151, -218, -6.87, 450)  -- NPC: an_ukun_lifebleeder
+		eq.spawn2(298042,0,0,  81, -113, -6.87,  194) -- NPC: an_ukun_manasipper
+		eq.spawn2(298041,0,0,  81, -218, -6.87,  40)  -- NPC: an_ukun_ragehound
+		eq.set_next_hp_event(30)
 	elseif e.hp_event == 30 then
-		eq.modify_npc_stat("min_hit", "1275");
-		eq.modify_npc_stat("max_hit", "5185");
-		eq.modify_npc_stat("ac", "700");
-		e.self:Say("I commend you on your tenacity, infidels. However I am through playing games. Witness the true fighting power of an Ixt Berserker.");
+		eq.modify_npc_stat("min_hit", "1275")
+		eq.modify_npc_stat("max_hit", "5185")
+		eq.modify_npc_stat("ac", "700")
+		e.self:Say("I commend you on your tenacity, infidels. However I am through playing games. Witness the true fighting power of an Ixt Berserker.")
 		-- should this be red zone emote?
-		eq.set_timer("cleaver", 30 * 1000);
-		eq.set_next_hp_event(10);
+		eq.set_timer("cleaver", 30 * 1000)
+		eq.set_next_hp_event(10)
 	elseif e.hp_event == 10 then
 		-- When she hits 10%, she will regenerate to 40% health and strip her debuffs
 		-- Balance of the nameless, strip self debuffs
-		e.self:CastSpell(3230,e.self:GetID()); -- Spell: Balance of the Nameless
+		e.self:CastSpell(3230,e.self:GetID()) -- Spell: Balance of the Nameless
+		e.self:BuffFadeAll()
 		e.self:SetHP(e.self:GetMaxHP()*0.40)
-		eq.modify_npc_stat("min_hit", "1245");
-		eq.modify_npc_stat("max_hit", "4665");
-		eq.zone_emote(MT.Red,"You may yet have the strength to defeat me but I am not through with you yet. Xxeric's eyes turn blood red as she enters an uncontrollable rage. Focusing on her wounds, she begins to recover some health.");
+		eq.modify_npc_stat("min_hit", "1245")
+		eq.modify_npc_stat("max_hit", "4665")
+		eq.zone_emote(MT.Red,"You may yet have the strength to defeat me but I am not through with you yet. Xxeric's eyes turn blood red as she enters an uncontrollable rage. Focusing on her wounds, she begins to recover some health.")
 	end
 end
 
 function PXK_Timer(e)
 	if e.timer == "cleaver" then
-		e.self:CastedSpellFinished(4729, e.self:GetHateRandom()); -- Spell: Spirit Cleaver
+		e.self:CastedSpellFinished(4729, e.self:GetHateRandom()) -- Spell: Spirit Cleaver
 	elseif e.timer == "rage" then
-		e.self:CastedSpellFinished(4728, e.self:GetHateRandom()); -- Spell: Wave of Rage
+		e.self:CastedSpellFinished(4728, e.self:GetHateRandom()) -- Spell: Wave of Rage
 	elseif e.timer == "check" then
 		--local rand = math.random(1,100);
 		--if (rand >= 85) then -- 15 % to cast throw
-		local instance_id = eq.get_zone_instance_id();
+		local instance_id = eq.get_zone_instance_id()
 		e.self:ForeachHateList(
 			function(ent, hate, damage, frenzy)
-				if(ent:IsClient() and ent:GetX() < 49 or ent:GetY() < -243 or ent:GetY() > -86 or ent:GetX() > 195) then
-					local currclient=ent:CastToClient();
-					--e.self:Shout("You will not evade me " .. currclient:GetName())
-					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-					currclient:Message(MT.Magenta,"Pixtt Xxeric Kex says, 'Did you think I would let you enter these halls without consequence?");
+				if (ent:IsClient() and ent:GetX() < 49 or ent:GetY() < -243 or ent:GetY() > -86 or ent:GetX() > 195) then
+					local currclient=ent:CastToClient()
+					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0) -- Zone: tacvi
+					currclient:Message(MT.Magenta,"Pixtt Xxeric Kex says, 'Did you think I would let you enter these halls without consequence?")
 				end
 			end
-		);
+		)
 	end
 end
 
 function PXK_Juxtapincer_Death(e)
 	if juxtapincer < 3 then
-		juxtapincer = juxtapincer + 1;
-		eq.spawn2(298044,0,0, 151, -113, -6.87, 314); -- NPC: an_ukun_juxtapincer
-		e.self:Emote("flesh and bones are reformed by dark magic");
+		juxtapincer = juxtapincer + 1
+		eq.spawn2(298044,0,0, 151, -113, -6.87, 314) -- NPC: an_ukun_juxtapincer
+		e.self:Emote("flesh and bones are reformed by dark magic")
 	end
 end
 
 function PXK_Lifebleeder_Death(e)
 	if lifebleeder < 3 then
-		lifebleeder = lifebleeder + 1;
-		eq.spawn2(298043,0,0, 151, -218, -6.87, 450); -- NPC: an_ukun_lifebleeder
-		e.self:Emote("flesh and bones are reformed by dark magic");
+		lifebleeder = lifebleeder + 1
+		eq.spawn2(298043,0,0, 151, -218, -6.87, 450) -- NPC: an_ukun_lifebleeder
+		e.self:Emote("flesh and bones are reformed by dark magic")
 	end
 end
 
 function PXK_Manasipper_Death(e)
 	if manasipper < 3 then
-		manasipper = manasipper + 1;
-		eq.spawn2(298042,0,0,  81, -113, -6.87,  194); -- NPC: an_ukun_manasipper
-		e.self:Emote("flesh and bones are reformed by dark magic");
+		manasipper = manasipper + 1
+		eq.spawn2(298042,0,0,  81, -113, -6.87,  194) -- NPC: an_ukun_manasipper
+		e.self:Emote("flesh and bones are reformed by dark magic")
 	end
 end
 
 function PXK_Ragehound_Death(e)
 	if ragehound < 3 then
-		ragehound = ragehound + 1;
-		eq.spawn2(298041,0,0,  81, -218, -6.87,  40); -- NPC: an_ukun_ragehound
-		e.self:Emote("flesh and bones are reformed by dark magic");
+		ragehound = ragehound + 1
+		eq.spawn2(298041,0,0,  81, -218, -6.87,  40) -- NPC: an_ukun_ragehound
+		e.self:Emote("flesh and bones are reformed by dark magic")
 	end
 end
 
 function event_encounter_load(e)
-	eq.register_npc_event('pxk', Event.spawn,  298039, PXK_Spawn);
-	eq.register_npc_event('pxk', Event.combat, 298039, PXK_Combat);
-	eq.register_npc_event('pxk', Event.hp,     298039, PXK_Hp);
-	eq.register_npc_event('pxk', Event.timer,     298039, PXK_Timer);
+	eq.register_npc_event('pxk', Event.spawn,  298039, PXK_Spawn)
+	eq.register_npc_event('pxk', Event.combat, 298039, PXK_Combat)
+	eq.register_npc_event('pxk', Event.hp,     298039, PXK_Hp)
+	eq.register_npc_event('pxk', Event.timer,  298039, PXK_Timer)
 
-	eq.register_npc_event('pxk', Event.death_complete, 298044, PXK_Juxtapincer_Death);
-	eq.register_npc_event('pxk', Event.death_complete, 298043, PXK_Lifebleeder_Death);
-	eq.register_npc_event('pxk', Event.death_complete, 298042, PXK_Manasipper_Death);
-	eq.register_npc_event('pxk', Event.death_complete, 298041, PXK_Ragehound_Death);
+	eq.register_npc_event('pxk', Event.death_complete, 298044, PXK_Juxtapincer_Death)
+	eq.register_npc_event('pxk', Event.death_complete, 298043, PXK_Lifebleeder_Death)
+	eq.register_npc_event('pxk', Event.death_complete, 298042, PXK_Manasipper_Death)
+	eq.register_npc_event('pxk', Event.death_complete, 298041, PXK_Ragehound_Death)
 
-	eq.register_npc_event('pxk', Event.death_complete, 298039, PXK_Death);
+	eq.register_npc_event('pxk', Event.death_complete, 298039, PXK_Death)
 end
 
 function event_encounter_unload(e)
-	eq.depop_all(298044);
-	eq.depop_all(298043);
-	eq.depop_all(298042);
-	eq.depop_all(298041);
-	eq.depop_all(298039);
+	eq.depop_all(298044)
+	eq.depop_all(298043)
+	eq.depop_all(298042)
+	eq.depop_all(298041)
+	eq.depop_all(298039)
 end

--- a/tacvi/encounters/tmcv.lua
+++ b/tacvi/encounters/tmcv.lua
@@ -1,349 +1,344 @@
-local Ukun_Inactive = "19,1^20,1^21,1^24,1^25,1"; 
-local Ukun_Active = "7,1^13,1^14,1^17,1^21,1";
+local Ukun_Inactive = "19,1^20,1^21,1^24,1^25,1"
+local Ukun_Active   = "7,1^13,1^14,1^17,1^21,1"
 
-local lp_mob = nil;
-local tunat_id = nil;
-local tunat_heal = nil;
-local tunat_hp = nil;
-local lp_list = {};
+local lp_mob     = nil
+local tunat_heal = nil
+local tunat_hp   = nil
+local lp_list    = {}
 
-local zmkp_min = nil;
-local zmkp_max = nil;
+local zmkp_min = nil
+local zmkp_max = nil
 
 function Tunat_Second_Spawn()
-	eq.set_next_hp_event(90);
+	eq.set_next_hp_event(90)
 end
 
 function Tunat_Second_Death(e)
-	eq.signal(298223, 298055); -- NPC: zone_status
-	eq.signal(298223,2); -- Unlock Doors
+	eq.signal(298223, 298055) -- NPC: zone_status
+	eq.signal(298223,2)       -- Unlock Doors
 end
 
 function Tunat_Second_HP(e)
 	if e.hp_event == 90 then
-		eq.signal(298223,1); -- Lock Doors
+		eq.signal(298223,1) -- Lock Doors
 
 		-- 90%: Pixtt Xxeric Kex (flurries; immediately spawns four ukun adds - stunnable, but not mezzable)
 
 		-- Stop Previous Spell Timers
-		eq.stop_timer("Spell_Tunat_Haste");
+		eq.stop_timer("Spell_Tunat_Haste")
 
 		-- Transition and set mob variables
-		e.self:Emote("shimmers and changes before your eyes.");
-		e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
-		eq.modify_npc_stat("min_hit", "1262");
-		eq.modify_npc_stat("max_hit", "4500");
-		e.self:SendIllusionPacket({race=393,gender=2,texture=11});
-		e.self:TempName("Pixtt Xxeric Kex");
+		e.self:Emote("shimmers and changes before your eyes.")
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 1)
+		eq.modify_npc_stat("min_hit", "1262")
+		eq.modify_npc_stat("max_hit", "4500")
+		e.self:SendIllusionPacket({race=393,gender=2,texture=11})
+		e.self:TempName("Pixtt Xxeric Kex")
 
 		-- Spawn Adds
-		eq.spawn2(298044, 0, 0, 334, -117, 21, 280); -- NPC: an_ukun_juxtapincer
-		eq.spawn2(298043, 0, 0, 356, -154, 21, 356); -- NPC: an_ukun_lifebleeder
-		eq.spawn2(298042, 0, 0, 353, -201, 21, 434); -- NPC: an_ukun_manasipper
-		eq.spawn2(298041, 0, 0, 322, -215, 21, 496); -- NPC: an_ukun_ragehound
+		eq.spawn2(298044, 0, 0, 334, -117, 21, 280) -- NPC: an_ukun_juxtapincer
+		eq.spawn2(298043, 0, 0, 356, -154, 21, 356) -- NPC: an_ukun_lifebleeder
+		eq.spawn2(298042, 0, 0, 353, -201, 21, 434) -- NPC: an_ukun_manasipper
+		eq.spawn2(298041, 0, 0, 322, -215, 21, 496) -- NPC: an_ukun_ragehound
 
 		-- Phase Spells
-		eq.set_timer("Spell_PXK_SC", 2 * 1000); -- 2s Start Timer
-		eq.set_timer("Spell_PXK_WOR", 60 * 1000); -- 60s Timer
+		eq.set_timer("Spell_PXK_SC", 2 * 1000)   -- 2s Start Timer
+		eq.set_timer("Spell_PXK_WOR", 60 * 1000) -- 60s Timer
 
 		-- Set next phase
-		eq.set_next_hp_event(80);
+		eq.set_next_hp_event(80)
 
 	elseif e.hp_event == 80 then
 		-- 80%: Pixtt Kretv Krakxt (mitigated AE rampage; spawns 4x "an ikaav hatchling" adds if you take too long)
 
 		-- Stop Previous Spell Timers
-		eq.stop_timer("Spell_PXK_SC");
-		eq.stop_timer("Spell_PXK_WOR");
+		eq.stop_timer("Spell_PXK_SC")
+		eq.stop_timer("Spell_PXK_WOR")
 
 		-- Transition and set mob variables
-		e.self:Emote("shimmers and changes before your eyes.");
-		e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
-		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
-		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 25); -- 75% mitigated aoe ramp dmg
-		eq.modify_npc_stat("min_hit", "1262");
-		eq.modify_npc_stat("max_hit", "4432");
-		e.self:SendIllusionPacket({race=394,gender=2,texture=11});
-		e.self:TempName("Pixtt Kretv Kakxt");
+		e.self:Emote("shimmers and changes before your eyes.")
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 0)
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1)
+		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 25) -- 75% mitigated aoe ramp dmg
+		eq.modify_npc_stat("min_hit", "1262")
+		eq.modify_npc_stat("max_hit", "4432")
+		e.self:SendIllusionPacket({race=394,gender=2,texture=11})
+		e.self:TempName("Pixtt Kretv Kakxt")
 
 		-- Add timer
-		eq.set_timer("pkk_adds", 30 * 1000);
+		eq.set_timer("pkk_adds", 30 * 1000)
 
 		-- Phase Spells
-		eq.set_timer("Spell_PKK_DV", 2 * 1000);	-- 2s Start Timer
-		eq.set_timer("Spell_PKK_SC", 5 * 1000);	-- 5s Start Timer
-		eq.set_timer("Spell_PKK_WOTI", 10 * 1000);	-- 10s Start Timer
+		eq.set_timer("Spell_PKK_DV", 2 * 1000)      -- 2s Start Timer
+		eq.set_timer("Spell_PKK_SC", 5 * 1000)	    -- 5s Start Timer
+		eq.set_timer("Spell_PKK_WOTI", 10 * 1000)	-- 10s Start Timer
 
 		-- Set next phase
-		eq.set_next_hp_event(70);
+		eq.set_next_hp_event(70)
 
 	elseif e.hp_event == 70 then
 		-- 70%: Pixtt Riel Tavas (unstable construct adds if you take too long)
 
 		-- Stop Previous Spell Timers
-		eq.stop_timer("Spell_PKK_DV");
-		eq.stop_timer("Spell_PKK_SC");
-		eq.stop_timer("Spell_PKK_WOTI");
+		eq.stop_timer("Spell_PKK_DV")
+		eq.stop_timer("Spell_PKK_SC")
+		eq.stop_timer("Spell_PKK_WOTI")
 
 		-- Transition and set mob variables
-		e.self:Emote("shimmers and changes before your eyes.");
-		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 0);
-		eq.modify_npc_stat("min_hit", "1552");
-		eq.modify_npc_stat("max_hit", "4600");
-		e.self:SendIllusionPacket({race=394,gender=2,texture=11});
-		e.self:TempName("Pixtt Riel Tavas");
+		e.self:Emote("shimmers and changes before your eyes.")
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 0)
+		eq.modify_npc_stat("min_hit", "1552")
+		eq.modify_npc_stat("max_hit", "4600")
+		e.self:SendIllusionPacket({race=394,gender=2,texture=11})
+		e.self:TempName("Pixtt Riel Tavas")
 
 		-- Add timer
-		eq.stop_timer("pkk_adds");
-		eq.set_timer("prt_adds", 30 * 1000);
+		eq.stop_timer("pkk_adds")
+		eq.set_timer("prt_adds", 30 * 1000)
 
 		-- Phase Spells
-		eq.set_timer("Spell_PRT_DV", 2 * 1000);	-- 2s Start Timer
-		eq.set_timer("Spell_PRT_WOTI", math.random(10,20) * 1000);	-- 10s-20 Start Timer
+		eq.set_timer("Spell_PRT_DV", 2 * 1000)	-- 2s Start Timer
+		eq.set_timer("Spell_PRT_WOTI", math.random(10,20) * 1000)	-- 10s-20 Start Timer
 
 		-- Set next phase
-		eq.set_next_hp_event(60);
+		eq.set_next_hp_event(60)
 
 	elseif e.hp_event == 60 then
 		-- 60%: Zun`Muram Kvxe Pirik (single-target rampage; Powers Up 30s; straight melee)
 
 		-- Stop Previous Spell Timers
-		eq.stop_timer("Spell_PRT_DV");
-		eq.stop_timer("Spell_PRT_WOTI");
+		eq.stop_timer("Spell_PRT_DV")
+		eq.stop_timer("Spell_PRT_WOTI")
 
 		-- Transition and set mob variables
-		e.self:Emote("shimmers and changes before your eyes.");
-		e.self:SendIllusionPacket({race=400,gender=2,texture=11});
-		e.self:TempName("Zun`Muram Kvxe Pirik");
-		e.self:ModifyNPCStat("attack_delay","9");
-		eq.modify_npc_stat("min_hit", "1424");
-		zmkp_min = 1424;
-		eq.modify_npc_stat("max_hit", "3900");
-		zmkp_max = 3900;
+		e.self:Emote("shimmers and changes before your eyes.")
+		e.self:SendIllusionPacket({race=400,gender=2,texture=11})
+		e.self:TempName("Zun`Muram Kvxe Pirik")
+		e.self:ModifyNPCStat("attack_delay","9")
+		eq.modify_npc_stat("min_hit", "1424")
+		zmkp_min = 1424
+		eq.modify_npc_stat("max_hit", "3900")
+		zmkp_max = 3900
 
 		-- Add timer
-		eq.stop_timer("prt_adds");
+		eq.stop_timer("prt_adds")
 
 		-- Power Up timer
-		eq.set_timer("zmkp_powerup_first", 35 * 1000);
+		eq.set_timer("zmkp_powerup_first", 35 * 1000)
 
 		-- Set next phase
-		eq.set_next_hp_event(50);
+		eq.set_next_hp_event(50)
 
 	elseif e.hp_event == 50 then
 		-- 50%: Zun`Muram Yihst Vor (mitigated AE rampage; Flurry; straight melee)
 
 		-- End power up cycle
-		eq.stop_timer("zmkp_powerup_repeat");
+		eq.stop_timer("zmkp_powerup_repeat")
 
 		-- Transition and set mob variables
-		e.self:Emote("shimmers and changes before your eyes.");
-		e.self:ModifyNPCStat("attack_delay","15");
-		eq.modify_npc_stat("min_hit", "1643");
-		eq.modify_npc_stat("max_hit", "4500");
-		e.self:SetSpecialAbility(SpecialAbility.rampage, 0);
-		e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
-		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
-		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 25); -- 75% mitigated aoe ramp dmg		
-		e.self:SendIllusionPacket({race=400,gender=2,texture=11});
-		e.self:TempName("Zun`Muram Yihst Vor");
+		e.self:Emote("shimmers and changes before your eyes.")
+		e.self:ModifyNPCStat("attack_delay","15")
+		eq.modify_npc_stat("min_hit", "1643")
+		eq.modify_npc_stat("max_hit", "4500")
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 0)
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 1)
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1)
+		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 25) -- 75% mitigated aoe ramp dmg		
+		e.self:SendIllusionPacket({race=400,gender=2,texture=11})
+		e.self:TempName("Zun`Muram Yihst Vor")
 		
 		-- Phase Spells
-		eq.set_timer("Spell_ZMYV_AOH", 60 * 1000); -- 60s Timer
+		eq.set_timer("Spell_ZMYV_AOH", 60 * 1000) -- 60s Timer
 
 		-- Set next phase
-		eq.set_next_hp_event(40);
+		eq.set_next_hp_event(40)
 
 	elseif e.hp_event == 40 then
 		-- 40%: Zun`Muram Mordl Delt (single-target rampage; flurries; spawns 2x "Zun`Muram Mordl Delt" adds)
 
 		-- Stop Previous Spell Timers
-		eq.stop_timer("Spell_ZMYV_AOH");
+		eq.stop_timer("Spell_ZMYV_AOH")
 
 		-- Transition and set mob variables
-		e.self:Emote("shimmers and changes before your eyes.");
-		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 0);
-		e.self:SetSpecialAbility(SpecialAbility.rampage, 1);
-		e.self:SetSpecialAbilityParam(SpecialAbility.rampage, 2, 25); -- 75% mitigated ramp dmg
-		eq.modify_npc_stat("min_hit", "1343");
-		eq.modify_npc_stat("max_hit", "4200");
-		e.self:SendIllusionPacket({race=400,gender=2,texture=11});
-		e.self:TempName("Zun`Muram Mordl Delt");
+		e.self:Emote("shimmers and changes before your eyes.")
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 0)
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 1)
+		eq.modify_npc_stat("min_hit", "1343")
+		eq.modify_npc_stat("max_hit", "4200")
+		e.self:SendIllusionPacket({race=400,gender=2,texture=11})
+		e.self:TempName("Zun`Muram Mordl Delt")
 
 		-- Spawn Adds
-		eq.set_timer("ZMMD_Adds",20 * 1000); -- Spawn Adds 20s after phase start
+		eq.set_timer("ZMMD_Adds",20 * 1000) -- Spawn Adds 20s after phase start
 		
 		-- Set next phase
-		eq.set_next_hp_event(30);
+		eq.set_next_hp_event(30)
 
 	elseif e.hp_event == 30 then
 		-- 30%: Zun`Muram Shaldn Boc (single-target rampage; Rages; straight melee)
 
 		-- Transition and set mob variables
-		e.self:Emote("shimmers and changes before your eyes.");
-		e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
-		eq.modify_npc_stat("min_hit", "1462");
-		eq.modify_npc_stat("max_hit", "4700");
-		e.self:SendIllusionPacket({race=400,gender=2,texture=11});
-		e.self:TempName("Zun`Muram Shaldn Boc");
+		e.self:Emote("shimmers and changes before your eyes.")
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 0)
+		eq.modify_npc_stat("min_hit", "1462")
+		eq.modify_npc_stat("max_hit", "4700")
+		e.self:SendIllusionPacket({race=400,gender=2,texture=11})
+		e.self:TempName("Zun`Muram Shaldn Boc")
 
 		-- Rage Timer
-		eq.set_timer("zmsb_rage", 30 * 1000);
-		
+		eq.set_timer("zmsb_rage", 30 * 1000)
+
 		-- Set next phase
-		eq.set_next_hp_event(20);
+		eq.set_next_hp_event(20)
 
 	elseif e.hp_event == 20 then
 		-- 20%: he reforms as Tunat`Muram Cuu Vauax once again...
 
 		-- Stop previous rage
-		eq.stop_timer("zmsb_rage");
-		eq.stop_timer("zmsb_rage_over");
+		eq.stop_timer("zmsb_rage")
+		eq.stop_timer("zmsb_rage_over")
 
 		-- Transition and set mob variables
-		e.self:Emote("shimmers and changes before your eyes.");
-		e.self:Say("You are stronger than I anticipated. While you have exhausted the fleeting spirit of my underlings, you have yet to face my true fury!");
-		eq.modify_npc_stat("min_hit", "1450");
-		eq.modify_npc_stat("max_hit", "4300");
-		e.self:SetSpecialAbility(SpecialAbility.rampage, 1);
-		e.self:SetSpecialAbilityParam(SpecialAbility.rampage, 2, 25); -- 75% mitigated ramp dmg
-		e.self:SetSpecialAbility(SpecialAbility.flurry, 1);
-		e.self:SendIllusionPacket({race=399,gender=2,texture=11});
-		e.self:TempName("Tunat`Muram Cuu Vauax");
+		e.self:Emote("shimmers and changes before your eyes.")
+		e.self:Say("You are stronger than I anticipated. While you have exhausted the fleeting spirit of my underlings, you have yet to face my true fury!")
+		eq.modify_npc_stat("min_hit", "1450")
+		eq.modify_npc_stat("max_hit", "4300")
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 1)
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 1)
+		e.self:SendIllusionPacket({race=399,gender=2,texture=11})
+		e.self:TempName("Tunat`Muram Cuu Vauax")
 
 		-- Rage Timer
-		eq.set_timer("tunat_rage", 30 * 1000);
-		eq.set_timer("Spell_Tunat_Haste",2 * 1000); -- 2s Start Timer
+		eq.set_timer("tunat_rage", 30 * 1000)
+		eq.set_timer("Spell_Tunat_Haste",2 * 1000) -- 2s Start Timer
 
 		-- Phase Spells
-		e.self:CastSpell(4740, e.self:GetID());	-- Spell: Haste of the Tunat`Muram
-		eq.set_timer("Spells_Tunat_Final1", 20 * 1000); -- 20s Start Timer
-		eq.set_timer("Spells_Tunat_Final2", 35 * 1000); -- 35s Start Timer
+		e.self:CastSpell(4740, e.self:GetID())	-- Spell: Haste of the Tunat`Muram
+		eq.set_timer("Spells_Tunat_Final1", 20 * 1000) -- 20s Start Timer
+		eq.set_timer("Spells_Tunat_Final2", 35 * 1000) -- 35s Start Timer
 
-		eq.set_next_hp_event(15);
+		eq.set_next_hp_event(15)
 	end
 end
 
 function Tunat_First_Death(e)
-	eq.zone_emote(MT.White, "Tunat`Muram Cuu Vauax says, 'In an explosion of energy, Tunat'Muram Cuu Vauax disappears while ancient pebbles pelt against your armor.'");
-	eq.zone_emote(MT.Yellow,"The room is filled with an eerie laugh. 'You have done well to defeat my doppelganger and have shown great strength by making it this far, but I'm afraid I must end your struggle here. Your days have been numbered since you first set foot upon this continent and your time is up. Kneel before me and I will grant you a quick death, but resist and you will suffer in ways that will be spoken about in hushed tones for eons to come.");
-	eq.spawn2(298055,0,0, 309, -170.8, 21.3, 118.8); -- NPC: #Tunat`Muram_Cuu_Vauax
-	eq.depop_all(298113);
-	eq.depop_all(298209);
+	eq.zone_emote(MT.White, "Tunat`Muram Cuu Vauax says, 'In an explosion of energy, Tunat'Muram Cuu Vauax disappears while ancient pebbles pelt against your armor.'")
+	eq.zone_emote(MT.Yellow,"The room is filled with an eerie laugh. 'You have done well to defeat my doppelganger and have shown great strength by making it this far, but I'm afraid I must end your struggle here. Your days have been numbered since you first set foot upon this continent and your time is up. Kneel before me and I will grant you a quick death, but resist and you will suffer in ways that will be spoken about in hushed tones for eons to come.")
+	eq.spawn2(298055,0,0, 309, -170.8, 21.3, 118.8) -- NPC: #Tunat`Muram_Cuu_Vauax
+	eq.depop_all(298113)
+	eq.depop_all(298209)
 end
 
 function Tunat_First_Spawn(e)
-	eq.signal(298223,2); -- Unlock Doors
-	eq.set_next_hp_event(90);
+	eq.signal(298223,2) -- Unlock Doors
+	eq.set_next_hp_event(90)
 
 	-- Spawn the Dogs
-	eq.spawn2(298209, 0, 0, 445, -203, 25, 34); -- NPC: an_ukun_biledrinker
-	eq.spawn2(298209, 0, 0, 447, -139, 25, 198); -- NPC: an_ukun_biledrinker
+	eq.spawn2(298209, 0, 0, 445, -203, 25, 34)  -- NPC: an_ukun_biledrinker
+	eq.spawn2(298209, 0, 0, 447, -139, 25, 198) -- NPC: an_ukun_biledrinker
 
 	-- Spawn the Living
-	lp_list[1] = eq.spawn2(298113, 0, 0,500.00, -152.00, 23.75, 112); -- NPC: Living_Phylactery
-	lp_list[2] = eq.spawn2(298113, 0, 0,507.00, -172.00, 23.75, 112); -- NPC: Living_Phylactery
-	lp_list[3] = eq.spawn2(298113, 0, 0,498.00, -193.00, 23.75, 112); -- NPC: Living_Phylactery
-	lp_list[4] = eq.spawn2(298113, 0, 0,476.00, -242.00, 23.75, 246); -- NPC: Living_Phylactery
-	lp_list[5] = eq.spawn2(298113, 0, 0,428.00, -242.00, 23.75, 246); -- NPC: Living_Phylactery
-	lp_list[6] = eq.spawn2(298113, 0, 0,454.00, -242.00, 23.75, 246); -- NPC: Living_Phylactery
-	lp_list[7] = eq.spawn2(298113, 0, 0,478.00, -100.00, 23.75, 28); -- NPC: Living_Phylactery
-	lp_list[8] = eq.spawn2(298113, 0, 0,454.00, -100.00, 23.75, 28); -- NPC: Living_Phylactery
-	lp_list[9] = eq.spawn2(298113, 0, 0,431.00, -100.00, 23.75, 28); -- NPC: Living_Phylactery
+	lp_list[1] = eq.spawn2(298113, 0, 0,500.00, -152.00, 23.75, 112) -- NPC: Living_Phylactery
+	lp_list[2] = eq.spawn2(298113, 0, 0,507.00, -172.00, 23.75, 112) -- NPC: Living_Phylactery
+	lp_list[3] = eq.spawn2(298113, 0, 0,498.00, -193.00, 23.75, 112) -- NPC: Living_Phylactery
+	lp_list[4] = eq.spawn2(298113, 0, 0,476.00, -242.00, 23.75, 246) -- NPC: Living_Phylactery
+	lp_list[5] = eq.spawn2(298113, 0, 0,428.00, -242.00, 23.75, 246) -- NPC: Living_Phylactery
+	lp_list[6] = eq.spawn2(298113, 0, 0,454.00, -242.00, 23.75, 246) -- NPC: Living_Phylactery
+	lp_list[7] = eq.spawn2(298113, 0, 0,478.00, -100.00, 23.75, 28)  -- NPC: Living_Phylactery
+	lp_list[8] = eq.spawn2(298113, 0, 0,454.00, -100.00, 23.75, 28)  -- NPC: Living_Phylactery
+	lp_list[9] = eq.spawn2(298113, 0, 0,431.00, -100.00, 23.75, 28)  -- NPC: Living_Phylactery
 
 end
 
 function Tunat_First_HP(e)
-	if (e.hp_event == 90) then
+	if e.hp_event == 90 then
 		eq.signal(298223,1); -- Lock Doors
-		eq.set_next_hp_event(40);
-	elseif (e.hp_event == 40) then
+		eq.set_next_hp_event(40)
+	elseif e.hp_event == 40 then
 		-- Wake up the dogs.
-		eq.signal(298209, 1); -- NPC: an_ukun_biledrinker
+		eq.signal(298209, 1) -- NPC: an_ukun_biledrinker
 	end
 end
 
 function Tunat_Second_Timer(e)
 	if e.timer == "pkk_adds" then
-		eq.spawn2(298013, 0, 0, 334, -117, 21, 280); -- NPC: an_ikaav_hatchling --change these so they dont trigger PKK Script.
-		eq.spawn2(298013, 0, 0, 356, -154, 21, 356); -- NPC: an_ikaav_hatchling
-		eq.spawn2(298013, 0, 0, 353, -201, 21, 434); -- NPC: an_ikaav_hatchling
-		eq.spawn2(298013, 0, 0, 322, -215, 21, 496); -- NPC: an_ikaav_hatchling
-
+		eq.spawn2(298013, 0, 0, 334, -117, 21, 280) -- NPC: an_ikaav_hatchling --change these so they dont trigger PKK Script.
+		eq.spawn2(298013, 0, 0, 356, -154, 21, 356) -- NPC: an_ikaav_hatchling
+		eq.spawn2(298013, 0, 0, 353, -201, 21, 434) -- NPC: an_ikaav_hatchling
+		eq.spawn2(298013, 0, 0, 322, -215, 21, 496) -- NPC: an_ikaav_hatchling
 	elseif e.timer == "prt_adds" then
-		eq.spawn2(298045, 0, 0, 334, -117, 21, 280); -- NPC: an_unstable_construct
-		eq.spawn2(298045, 0, 0, 356, -154, 21, 356); -- NPC: an_unstable_construct
-		eq.spawn2(298045, 0, 0, 353, -201, 21, 434); -- NPC: an_unstable_construct
-		eq.spawn2(298045, 0, 0, 322, -215, 21, 496); -- NPC: an_unstable_construct
-		eq.spawn2(298045, 0, 0, 322, -225, 21, 496); -- NPC: an_unstable_construct
+		eq.spawn2(298045, 0, 0, 334, -117, 21, 280) -- NPC: an_unstable_construct
+		eq.spawn2(298045, 0, 0, 356, -154, 21, 356) -- NPC: an_unstable_construct
+		eq.spawn2(298045, 0, 0, 353, -201, 21, 434) -- NPC: an_unstable_construct
+		eq.spawn2(298045, 0, 0, 322, -215, 21, 496) -- NPC: an_unstable_construct
+		eq.spawn2(298045, 0, 0, 322, -225, 21, 496) -- NPC: an_unstable_construct
 	elseif e.timer == "zmkp_powerup_first" then
-		eq.stop_timer("zmkp_powerup_first");
+		eq.stop_timer("zmkp_powerup_first")
 
 		-- Set Ramp - Observed 25%
-		e.self:SetSpecialAbility(SpecialAbility.rampage, 1);
-		e.self:SetSpecialAbilityParam(SpecialAbility.rampage, 2, 25); -- 75% mitigated ramp dmg
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 1)
 
-		e.self:ModifyNPCStat("attack_delay","28");
+		e.self:ModifyNPCStat("attack_delay","28")
 
 		-- Scale up each cycle - +700  max hit / +188 min hit
-		zmkp_min = zmkp_min + 188;
-		eq.modify_npc_stat("min_hit", tostring(zmkp_min));
-		zmkp_max = zmkp_max + 700;
-		eq.modify_npc_stat("max_hit", tostring(zmkp_max));
+		zmkp_min = zmkp_min + 188
+		eq.modify_npc_stat("min_hit", tostring(zmkp_min))
+		zmkp_max = zmkp_max + 700
+		eq.modify_npc_stat("max_hit", tostring(zmkp_max))
 		-- Start cycle
-		eq.set_timer("zmkp_powerup_repeat", 35 * 1000);		
+		eq.set_timer("zmkp_powerup_repeat", 35 * 1000)
 	elseif e.timer == "zmkp_powerup_repeat" then
 		-- Scale up each cycle - +700  max hit / +188 min hit
-		eq.zone_emote(MT.Yellow,"Zun`Muram Kvxe Pirik focuses his will and grows stronger.");
-		zmkp_min = zmkp_min + 188;
-		eq.modify_npc_stat("min_hit", tostring(zmkp_min));
-		zmkp_max = zmkp_max + 700;
-		eq.modify_npc_stat("max_hit", tostring(zmkp_max));
+		eq.zone_emote(MT.Yellow,"Zun`Muram Kvxe Pirik focuses his will and grows stronger.")
+		zmkp_min = zmkp_min + 188
+		eq.modify_npc_stat("min_hit", tostring(zmkp_min))
+		zmkp_max = zmkp_max + 700
+		eq.modify_npc_stat("max_hit", tostring(zmkp_max))
 	elseif e.timer == "ZMMD_Adds" then
-		eq.stop_timer("ZMMD_Adds");
-		eq.spawn2(298050, 0, 0, 334, -117, 21, 280); -- NPC: Zun`Muram_Mordl_Delt
-		eq.spawn2(298050, 0, 0, 356, -154, 21, 356); -- NPC: Zun`Muram_Mordl_Delt
+		eq.stop_timer("ZMMD_Adds")
+		eq.spawn2(298050, 0, 0, 334, -117, 21, 280) -- NPC: Zun`Muram_Mordl_Delt
+		eq.spawn2(298050, 0, 0, 356, -154, 21, 356) -- NPC: Zun`Muram_Mordl_Delt
 	elseif e.timer == "zmsb_rage" then
-		eq.zone_emote(MT.Yellow,"Zun`Muram Shaldn Boc starts to foam at the mouth as he enters a blind rage.");
-		eq.stop_timer("zmsb_rage");
-		e.self:ModifyNPCStat("attack_delay","9");
-		eq.modify_npc_stat("min_hit", "2010");
-		eq.modify_npc_stat("max_hit", "6200");
-		eq.set_timer("zmsb_rage_over", 25 * 1000);
+		eq.zone_emote(MT.Yellow,"Zun`Muram Shaldn Boc starts to foam at the mouth as he enters a blind rage.")
+		eq.stop_timer("zmsb_rage")
+		e.self:ModifyNPCStat("attack_delay","9")
+		eq.modify_npc_stat("min_hit", "2010")
+		eq.modify_npc_stat("max_hit", "6200")
+		eq.set_timer("zmsb_rage_over", 25 * 1000)
 	elseif e.timer == "zmsb_rage_over" then
-		eq.zone_emote(MT.Yellow,"Zun`Muram Shaldn Boc looks weakened as the rage ends.");
-		eq.stop_timer("zmsb_rage_over");
-		e.self:ModifyNPCStat("attack_delay","15");
-		eq.modify_npc_stat("min_hit", "1462");
-		eq.modify_npc_stat("max_hit", "4700");
-		eq.set_timer("zmsb_rage", 30 * 1000);
+		eq.zone_emote(MT.Yellow,"Zun`Muram Shaldn Boc looks weakened as the rage ends.")
+		eq.stop_timer("zmsb_rage_over")
+		e.self:ModifyNPCStat("attack_delay","15")
+		eq.modify_npc_stat("min_hit", "1462")
+		eq.modify_npc_stat("max_hit", "4700")
+		eq.set_timer("zmsb_rage", 30 * 1000)
 	elseif e.timer == "tunat_rage" then
-		eq.zone_emote(MT.Yellow,"Tunat`Muram Cuu Vuaux starts to foam at the mouth as he enters a blind rage.");
-		eq.stop_timer("tunat_rage");
-		e.self:ModifyNPCStat("attack_delay","9");
-		eq.modify_npc_stat("min_hit", "1990");
-		eq.modify_npc_stat("max_hit", "5800");
-		eq.set_timer("tunat_rage_over", 25 * 1000);
+		eq.zone_emote(MT.Yellow,"Tunat`Muram Cuu Vuaux starts to foam at the mouth as he enters a blind rage.")
+		eq.stop_timer("tunat_rage")
+		e.self:ModifyNPCStat("attack_delay","9")
+		eq.modify_npc_stat("min_hit", "1990")
+		eq.modify_npc_stat("max_hit", "5800")
+		eq.set_timer("tunat_rage_over", 25 * 1000)
 	elseif e.timer == "tunat_rage_over" then
-		eq.zone_emote(MT.Yellow,"Tunat`Muram Cuu Vuaux looks weakened as the rage ends.");
-		eq.stop_timer("tunat_rage_over");
-		e.self:ModifyNPCStat("attack_delay","15");
-		eq.modify_npc_stat("min_hit", "1450");
-		eq.modify_npc_stat("max_hit", "4300");
-		eq.set_timer("tunat_rage", 30 * 1000);
+		eq.zone_emote(MT.Yellow,"Tunat`Muram Cuu Vuaux looks weakened as the rage ends.")
+		eq.stop_timer("tunat_rage_over")
+		e.self:ModifyNPCStat("attack_delay","15")
+		eq.modify_npc_stat("min_hit", "1450")
+		eq.modify_npc_stat("max_hit", "4300")
+		eq.set_timer("tunat_rage", 30 * 1000)
 	elseif e.timer == "wipe_check2" then
-		eq.stop_all_timers();
-		eq.signal(298223,2); -- Unlock Doors
-		eq.depop_all(298044);
-		eq.depop_all(298043);
-		eq.depop_all(298042);
-		eq.depop_all(298041);
-		eq.depop_all(298048);
-		eq.depop_all(298045);
-		eq.depop_all(298209);
-		eq.depop_all(298050);
-		eq.depop_all(298013);
-		eq.spawn2(298055,0,0, 309, -170.8, 21.3, 118.8); -- NPC: #Tunat`Muram_Cuu_Vauax
+		eq.stop_all_timers()
+		eq.signal(298223,2) -- Unlock Doors
+		eq.depop_all(298044)
+		eq.depop_all(298043)
+		eq.depop_all(298042)
+		eq.depop_all(298041)
+		eq.depop_all(298048)
+		eq.depop_all(298045)
+		eq.depop_all(298209)
+		eq.depop_all(298050)
+		eq.depop_all(298013)
+		eq.spawn2(298055,0,0, 309, -170.8, 21.3, 118.8) -- NPC: #Tunat`Muram_Cuu_Vauax
 		eq.depop();
 
 	--
@@ -352,183 +347,182 @@ function Tunat_Second_Timer(e)
 
 	-- Tunat 100%
 	elseif e.timer == "Spell_Tunat_Haste" then
-		eq.stop_timer("Spell_Tunat_Haste");
-		if (e.self:GetHPRatio() > 90 or e.self:GetHPRatio() < 20) then
-			e.self:CastSpell(4740, e.self:GetID()); -- Spell: Haste of the Tunat`Muram
+		eq.stop_timer("Spell_Tunat_Haste")
+		if e.self:GetHPRatio() > 90 or e.self:GetHPRatio() < 20 then
+			e.self:CastSpell(4740, e.self:GetID()) -- Spell: Haste of the Tunat`Muram
 		end
-		eq.set_timer("Spell_Tunat_Haste",30 * 1000); -- 30s Timer
+		eq.set_timer("Spell_Tunat_Haste",30 * 1000) -- 30s Timer
 
 	-- PXK 90%	
 	elseif e.timer == "Spell_PXK_SC" then
-		eq.stop_timer("Spell_PXK_SC");
-		e.self:CastedSpellFinished(4729, e.self:GetHateTop());	-- Spell: Spirit Cleaver: Single Target, Prismatic (-350)
-		eq.set_timer("Spell_PXK_SC",math.random(45,60) * 1000); -- Random 45-60s Timer
+		eq.stop_timer("Spell_PXK_SC")
+		e.self:CastedSpellFinished(4729, e.self:GetHateTop())	-- Spell: Spirit Cleaver: Single Target, Prismatic (-350)
+		eq.set_timer("Spell_PXK_SC",math.random(45,60) * 1000) -- Random 45-60s Timer
 
 	elseif e.timer == "Spell_PXK_WOR" then
-		e.self:CastedSpellFinished(4728, e.self:GetHateTop());	-- Spell: Wave of Rage: PB AE 100', Prismatic (-350)
+		e.self:CastedSpellFinished(4728, e.self:GetHateTop())	-- Spell: Wave of Rage: PB AE 100', Prismatic (-350)
 
 	-- PKK 80%	
 	elseif e.timer == "Spell_PKK_DV" then
-		eq.stop_timer("Spell_PKK_DV");
-		e.self:CastedSpellFinished(889, e.self:GetHateTop());	-- Spell: Delusional Visions: Single Target, Chromatic (-350)
-		eq.set_timer("Spell_PKK_DV",30 * 1000); -- 30s Timer
+		eq.stop_timer("Spell_PKK_DV")
+		e.self:CastedSpellFinished(889, e.self:GetHateTop())	-- Spell: Delusional Visions: Single Target, Chromatic (-350)
+		eq.set_timer("Spell_PKK_DV",30 * 1000) -- 30s Timer
 
 	elseif e.timer == "Spell_PKK_SC" then
-		eq.stop_timer("Spell_PKK_SC");
-		e.self:CastedSpellFinished(852, e.self:GetHateTop());	-- Spell: Soul Consumption: Single Target, Prismatic (-350)
-		eq.set_timer("Spell_PKK_SC",math.random(35,45) * 1000); -- Random 35-45s Timer
+		eq.stop_timer("Spell_PKK_SC")
+		e.self:CastedSpellFinished(852, e.self:GetHateTop())	-- Spell: Soul Consumption: Single Target, Prismatic (-350)
+		eq.set_timer("Spell_PKK_SC",math.random(35,45) * 1000) -- Random 35-45s Timer
 
 	elseif e.timer == "Spell_PKK_WOTI" then
-		eq.stop_timer("Spell_PKK_WOTI");
-		e.self:CastedSpellFinished(888, e.self:GetHateTop());	-- Spell: Wrath of the Ikaav: Single Target, Unresistable
-		eq.set_timer("Spell_PKK_WOTI",math.random(30,60) * 1000); -- Random 30-60s Timer
+		eq.stop_timer("Spell_PKK_WOTI")
+		e.self:CastedSpellFinished(888, e.self:GetHateTop())	-- Spell: Wrath of the Ikaav: Single Target, Unresistable
+		eq.set_timer("Spell_PKK_WOTI",math.random(30,60) * 1000) -- Random 30-60s Timer
 
 	-- PRT 70%	
 	elseif e.timer == "Spell_PRT_DV" then
-		eq.stop_timer("Spell_PRT_DV");
-		e.self:CastedSpellFinished(889, e.self:GetHateTop());	-- Spell: Delusional Visions: Single Target, Chromatic (-350)
-		eq.set_timer("Spell_PRT_DV",math.random(30,60) * 1000); -- Random 30-60s Timer
+		eq.stop_timer("Spell_PRT_DV")
+		e.self:CastedSpellFinished(889, e.self:GetHateTop())	-- Spell: Delusional Visions: Single Target, Chromatic (-350)
+		eq.set_timer("Spell_PRT_DV",math.random(30,60) * 1000) -- Random 30-60s Timer
 
 	elseif e.timer == "Spell_PRT_WOTI" then
-		eq.stop_timer("Spell_PRT_WOTI");
-		e.self:CastedSpellFinished(888, e.self:GetHateTop());	-- Spell: Wrath of the Ikaav: Single Target, Unresistable
-		eq.set_timer("Spell_PRT_WOTI",math.random(60,180) * 1000); -- Random 60-180s Timer
+		eq.stop_timer("Spell_PRT_WOTI")
+		e.self:CastedSpellFinished(888, e.self:GetHateTop())	-- Spell: Wrath of the Ikaav: Single Target, Unresistable
+		eq.set_timer("Spell_PRT_WOTI",math.random(60,180) * 1000) -- Random 60-180s Timer
 
 	-- PRT 50%
 	elseif e.timer == "Spell_ZMYV_AOH" then
-		eq.stop_timer("Spell_ZMYV_AOH");
-		
-		for i=1,2 do -- Two Casts
-			local target = e.self:GetHateRandom();
+		eq.stop_timer("Spell_ZMYV_AOH")
+
+		for i = 1,2 do -- Two Casts
+			local target = e.self:GetHateRandom()
 			if target:IsPet() then
-				target = target:GetOwner();
+				target = target:GetOwner()
 			end
 
 			if target.valid and not target:FindBuff(4441) then
-				e.self:SpellFinished(4441, target); -- Spell: Allure of Hatred
+				e.self:SpellFinished(4441, target) -- Spell: Allure of Hatred
 			end
 		end
 
-		e.self:WipeHateList();
-		eq.set_timer("Spell_ZMYV_AOH",60 * 1000); -- 60s Timer
+		e.self:WipeHateList()
+		eq.set_timer("Spell_ZMYV_AOH",60 * 1000) -- 60s Timer
 
 	-- Tunat 20%
 	elseif e.timer == "Spells_Tunat_Final1" then
-		--spear of discord [20s interval ]
-		--spirit cleaver [20s interval ]
-		--soul consumption [20s interval ]
-		e.self:CastedSpellFinished(eq.ChooseRandom(4727, 4729, 852), e.self:GetHateRandom());
-		
+		-- spear of discord [20s interval ]
+		-- spirit cleaver   [20s interval ]
+		-- soul consumption [20s interval ]
+		e.self:CastedSpellFinished(eq.ChooseRandom(4727, 4729, 852), e.self:GetHateRandom())
 	elseif e.timer == "Spells_Tunat_Final2" then
-		--ikaavs venom [35s interval ]
-		--wave of rage [35s interval ]
-		--discords rebuke [35s interval ]
-		e.self:CastedSpellFinished(eq.ChooseRandom(751, 4739, 4728), e.self:GetHateRandom());
+		-- ikaavs venom    [35s interval ]
+		-- wave of rage    [35s interval ]
+		-- discords rebuke [35s interval ]
+		e.self:CastedSpellFinished(eq.ChooseRandom(751, 4739, 4728), e.self:GetHateRandom())
 	end
 end
 
 function Tunat_Second_Combat(e)
 	if e.joined then
-		eq.stop_timer("wipe_check2");
-		eq.set_timer("Spell_Tunat_Haste", 2 * 1000); -- 2s Start Timer
+		eq.stop_timer("wipe_check2")
+		eq.set_timer("Spell_Tunat_Haste", 2 * 1000) -- 2s Start Timer
 	else
-		eq.set_timer("wipe_check2", 300 * 1000);
+		eq.set_timer("wipe_check2", 300 * 1000)
 	end
 end
 
 function Tunat_First_Combat(e)
 	if e.joined then
-		e.self:Say("You have defiled my chambers and destroyed my officers. I will crush your soul and suck the marrow from your bones.");
-		eq.set_timer("lp_store", eq.ChooseRandom(40, 49, 50, 65, 111) * 1000);
-		eq.stop_timer("wipe_check1");
+		e.self:Say("You have defiled my chambers and destroyed my officers. I will crush your soul and suck the marrow from your bones.")
+		eq.set_timer("lp_store", eq.ChooseRandom(40, 49, 50, 65, 111) * 1000)
+		eq.stop_timer("wipe_check1")
 	else
-		eq.set_timer("wipe_check1", 300 * 1000);
+		eq.set_timer("wipe_check1", 300 * 1000)
 	end
 end
 
 function Tunat_First_Timer(e)
 	if e.timer == "lp_store" then
-		eq.stop_timer("lp_store");
-		e.self:Emote("pauses for a moment as a portion of his spirit is transferred into one of the phylacteries. ");
+		eq.stop_timer("lp_store")
+		e.self:Emote("pauses for a moment as a portion of his spirit is transferred into one of the phylacteries. ")
 
-		lp_mob = lp_list[ eq.ChooseRandom(1,2,3,4,5,6,7,8,9)]; 
-		tunat_heal = e.self:GetMaxHP() * 0.10;
+		lp_mob = lp_list[ eq.ChooseRandom(1,2,3,4,5,6,7,8,9)]
+		tunat_heal = e.self:GetMaxHP() * 0.10
 
-		e.self:FaceTarget(lp_mob);
-		e.self:CastSpell(4448, lp_mob:GetID(), 1, 2); -- Spell: ShieldSP
+		e.self:FaceTarget(lp_mob)
+		e.self:CastSpell(4448, lp_mob:GetID(), 1, 2) -- Spell: ShieldSP
 
-		eq.set_timer("lp_heal", 30 * 1000 );
+		eq.set_timer("lp_heal", 30 * 1000 )
 	elseif e.timer == "lp_heal" then
-		eq.stop_timer("lp_heal");
-		eq.set_timer("lp_store", eq.ChooseRandom(40, 49, 50, 65, 111) * 1000);
+		eq.stop_timer("lp_heal")
+		eq.set_timer("lp_store", eq.ChooseRandom(40, 49, 50, 65, 111) * 1000)
 		
-		tunat_id = e.self:GetID();
-		tunat_hp = e.self:GetHP();
+		tunat_id = e.self:GetID()
+		tunat_hp = e.self:GetHP()
 
-		lp_mob:FaceTarget(e.self);
-		lp_mob:CastSpell(4448, e.self:GetID(), 1, 3 ); -- Spell: ShieldSP
-		e.self:SetHP( tunat_hp + tunat_heal );
-		e.self:Emote("staggers as the portion of his spirit that was stored in the phylactery flows back into him.");
+		lp_mob:FaceTarget(e.self)
+		lp_mob:CastSpell(4448, e.self:GetID(), 1, 3 ) -- Spell: ShieldSP
+		e.self:SetHP( tunat_hp + tunat_heal )
+		e.self:Emote("staggers as the portion of his spirit that was stored in the phylactery flows back into him.")
 
 	elseif e.timer == "wipe_check1" then
 		-- Reset to the 1st Tunat 
-		eq.signal(298223,2); -- Unlock Doors
-		eq.depop();
-		eq.depop_all(298113);
-		eq.depop_all(298209);
-		eq.spawn2(298014, 0, 0, 462, -171, 32, 16); -- NPC: #Tunat`Muram_Cuu_Vauax
+		eq.signal(298223,2) -- Unlock Doors
+		eq.depop()
+		eq.depop_all(298113)
+		eq.depop_all(298209)
+		eq.spawn2(298014, 0, 0, 462, -171, 32, 16) -- NPC: #Tunat`Muram_Cuu_Vauax
 
 	end
 end
 
 function LP_Combat(e)
 	if e.joined then
-		eq.set_timer("lp_ae", 30 * 1000);
+		eq.set_timer("lp_ae", 30 * 1000)
 	end
 end
 
 function LP_Death(e)
-	e.self:SpellFinished(6495, e.self); -- Spell: Spiritual Wake
+	e.self:SpellFinished(6495, e.self) -- Spell: Spiritual Wake
 end
 
 function LP_Timer(e)
 	if e.timer == "lp_ae" then
-		e.self:CastSpell(5546, e.self:GetTarget():GetID()); -- Spell: Gaze of the Tunat`Muram
+		e.self:CastSpell(5546, e.self:GetTarget():GetID()) -- Spell: Gaze of the Tunat`Muram
 	end
 end
 
 function Ukun_Spawn(e)
 	-- When the Dogs spawn set the inactive
-	e.self:ProcessSpecialAbilities(Ukun_Inactive);
-	eq.signal(298209, 2, 2 * 1000); -- NPC: an_ukun_biledrinker
+	e.self:ProcessSpecialAbilities(Ukun_Inactive)
+	eq.signal(298209, 2, 2 * 1000);-- NPC: an_ukun_biledrinker
 end
 
 function Ukun_Signal(e)
 	if e.signal == 1 then
  		-- When we get a signal fromt he controller wake the dogs up.
-		e.self:ProcessSpecialAbilities(Ukun_Active);
+		e.self:ProcessSpecialAbilities(Ukun_Active)
 	elseif e.signal == 2 then
-		e.self:SetAppearance(3); -- Dead
+		e.self:SetAppearance(3) -- Dead
 	end
 end
 
 function event_encounter_load(e)
-	eq.register_npc_event("tmcv", Event.spawn,          298014, Tunat_First_Spawn);
-	eq.register_npc_event("tmcv", Event.death_complete, 298014, Tunat_First_Death);
-	eq.register_npc_event("tmcv", Event.hp,             298014, Tunat_First_HP);
-	eq.register_npc_event("tmcv", Event.timer,          298014, Tunat_First_Timer);
-	eq.register_npc_event("tmcv", Event.combat,         298014, Tunat_First_Combat);
+	eq.register_npc_event("tmcv", Event.spawn,          298014, Tunat_First_Spawn)
+	eq.register_npc_event("tmcv", Event.death_complete, 298014, Tunat_First_Death)
+	eq.register_npc_event("tmcv", Event.hp,             298014, Tunat_First_HP)
+	eq.register_npc_event("tmcv", Event.timer,          298014, Tunat_First_Timer)
+	eq.register_npc_event("tmcv", Event.combat,         298014, Tunat_First_Combat)
 
-	eq.register_npc_event("tmcv", Event.spawn,          298055, Tunat_Second_Spawn);
-	eq.register_npc_event("tmcv", Event.combat,         298055, Tunat_Second_Combat);
-	eq.register_npc_event("tmcv", Event.death_complete, 298055, Tunat_Second_Death);
-	eq.register_npc_event("tmcv", Event.hp,             298055, Tunat_Second_HP);
-	eq.register_npc_event("tmcv", Event.timer,          298055, Tunat_Second_Timer);
+	eq.register_npc_event("tmcv", Event.spawn,          298055, Tunat_Second_Spawn)
+	eq.register_npc_event("tmcv", Event.combat,         298055, Tunat_Second_Combat)
+	eq.register_npc_event("tmcv", Event.death_complete, 298055, Tunat_Second_Death)
+	eq.register_npc_event("tmcv", Event.hp,             298055, Tunat_Second_HP)
+	eq.register_npc_event("tmcv", Event.timer,          298055, Tunat_Second_Timer)
 
-	eq.register_npc_event("tmcv", Event.combat,         298113, LP_Combat);
-	eq.register_npc_event("tmcv", Event.death,          298113, LP_Death);
-	eq.register_npc_event("tmcv", Event.timer,          298113, LP_Timer);
+	eq.register_npc_event("tmcv", Event.combat,         298113, LP_Combat)
+	eq.register_npc_event("tmcv", Event.death,          298113, LP_Death)
+	eq.register_npc_event("tmcv", Event.timer,          298113, LP_Timer)
 
-	eq.register_npc_event("tmcv", Event.spawn,          298209, Ukun_Spawn);
-	eq.register_npc_event("tmcv", Event.signal,         298209, Ukun_Signal);
+	eq.register_npc_event("tmcv", Event.spawn,          298209, Ukun_Spawn)
+	eq.register_npc_event("tmcv", Event.signal,         298209, Ukun_Signal)
 end

--- a/tacvi/encounters/zmkp.lua
+++ b/tacvi/encounters/zmkp.lua
@@ -1,328 +1,261 @@
-local ZMKP_Active = "1,1^2,1^3,1^5,1^7,1^13,1^14,1^15,1^16,1^17,1^21,1^42,1";
-local ZMKP_Inactive = "19,1^20,1^21,1^24,1^25,1";
+local ZMKP_Active = "1,1^2,1^3,1^5,1^7,1^13,1^14,1^15,1^16,1^17,1^21,1^42,1"
+local ZMKP_Inactive = "19,1^20,1^21,1^24,1^25,1"
 
-local ZMKP_AC     = 568; -- Defense
-local ZMKP_MaxHit = 3900; -- Fury
-local ZMKP_MinHit = 1430;
-local ZMKP_AtkHit = 400; -- Rage
-local ZMKP_Delay  = 20;
+local ZMKP_AC     = 568 -- Defense
+local ZMKP_MaxHit = 3900 -- Fury
+local ZMKP_MinHit = 1430
+local ZMKP_AtkHit = 400 -- Rage
+local ZMKP_Delay  = 20
 
 -- Time out on Balancing seemed to be about 70 seconds
-local ZMKP_Balance_Timer = 70 * 1000;
-local ZMKP_Fury = 100;
-local ZMKP_Rage = 100;
-local ZMKP_Speed = 100;
-local ZMKP_Defense = 100;
-local target_hp = 90;
-local defense_balanced = false;
-local fury_balanced = false;
-local rage_balanced = false;
-local speed_balanced = false;
+local ZMKP_Balance_Timer = 70 * 1000
+
+local target_hp = 90
+
+local defense_balanced = false
+local fury_balanced    = false
+local rage_balanced    = false
+local speed_balanced   = false
 
 function ZMKP_Spawn(e)
-	eq.spawn2(298125, 0, 0, 412.0, -714.0, -4.125, 454); -- NPC: #Balance_of_Speed
-	eq.spawn2(298126, 0, 0, 339.0, -714.0, -4.125, 88); -- NPC: #Balance_of_Defense
-	eq.spawn2(298127, 0, 0, 412.0, -646.0, -4.125, 318); -- NPC: #Balance_of_Fury
-	eq.spawn2(298128, 0, 0, 339.0, -646.0, -4.125, 190); -- NPC: #Balance_of_Rage
+	eq.spawn2(298125, 0, 0, 412.0, -714.0, -4.125, 454) -- NPC: #Balance_of_Speed
+	eq.spawn2(298126, 0, 0, 339.0, -714.0, -4.125, 88)  -- NPC: #Balance_of_Defense
+	eq.spawn2(298127, 0, 0, 412.0, -646.0, -4.125, 318) -- NPC: #Balance_of_Fury
+	eq.spawn2(298128, 0, 0, 339.0, -646.0, -4.125, 190) -- NPC: #Balance_of_Rage
 
-	ZMKP_AC     = 568; -- Defense
-	ZMKP_MaxHit = 3900; -- Fury
-	ZMKP_MinHit = 1430;
-	ZMKP_AtkHit = 400; -- Rage
-	ZMKP_Delay  = 20;
+	ZMKP_AC     = 568 -- Defense
+	ZMKP_MaxHit = 3900 -- Fury
+	ZMKP_MinHit = 1430
+	ZMKP_AtkHit = 400 -- Rage
+	ZMKP_Delay  = 20
 
-	e.self:ModifyNPCStat("ac",            tostring(ZMKP_AC));
-	e.self:ModifyNPCStat("max_hit",       tostring(ZMKP_MaxHit));
-	e.self:ModifyNPCStat("min_hit",       tostring(ZMKP_MinHit));
-	e.self:ModifyNPCStat("atk",           tostring(ZMKP_AtkHit));
-	e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay));
-	eq.set_next_hp_event(90);
-	target_hp = 90;
+	e.self:ModifyNPCStat("ac",            tostring(ZMKP_AC))
+	e.self:ModifyNPCStat("max_hit",       tostring(ZMKP_MaxHit))
+	e.self:ModifyNPCStat("min_hit",       tostring(ZMKP_MinHit))
+	e.self:ModifyNPCStat("atk",           tostring(ZMKP_AtkHit))
+	e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay))
+	eq.set_next_hp_event(90)
+	target_hp = 90
 end
 
 function ZMKP_Combat(e)
 	if e.joined then
-		e.self:Emote("Come you fools! Show me your strongest warrior and I will show you my first victim.");
+		e.self:Emote("Come you fools! Show me your strongest warrior and I will show you my first victim.")
 	else
-		eq.set_timer("wipecheck", 1 * 1000);
+		eq.set_timer("wipecheck", 1 * 1000)
 	end
 end
 
 function ZMKP_Timer(e)
 	if e.timer == 'balance' then
-		eq.stop_timer(e.timer);
-		eq.stop_timer("wipecheck");
-		eq.signal(298125, 1); -- NPC: #Balance_of_Speed
-		eq.signal(298126, 1); -- NPC: #Balance_of_Defense
-		eq.signal(298127, 1); -- NPC: #Balance_of_Fury
-		eq.signal(298128, 1); -- NPC: #Balance_of_Rage
+		eq.stop_timer(e.timer)
+		eq.stop_timer("wipecheck")
+		eq.signal(298125, 1) -- NPC: #Balance_of_Speed
+		eq.signal(298126, 1) -- NPC: #Balance_of_Defense
+		eq.signal(298127, 1) -- NPC: #Balance_of_Fury
+		eq.signal(298128, 1) -- NPC: #Balance_of_Rage
 
-		local failed = false;
+		local failed = false
 
 		if not speed_balanced then
 			-- Reduce ZMKP's Attack Delay by 10% each time the Speed mob is out of Balance.
-			ZMKP_Delay = ZMKP_Delay * 0.90;
-			e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay));
-			failed = true;
+			ZMKP_Delay = ZMKP_Delay - 2
+			e.self:ModifyNPCStat("attack_delay", tostring(ZMKP_Delay))
+			failed = true
 		end
+
 		if not defense_balanced then
-			ZMKP_AC = ZMKP_AC + 100;
-			e.self:ModifyNPCStat("ac",            tostring(ZMKP_AC));
-			failed = true;
+			ZMKP_AC = ZMKP_AC + 100
+			e.self:ModifyNPCStat("ac", tostring(ZMKP_AC))
+			failed = true
 		end
+
 		if not fury_balanced then
 			ZMKP_MaxHit = ZMKP_MaxHit + 585;
 			ZMKP_MinHit = ZMKP_MinHit + 215;
-			e.self:ModifyNPCStat("max_hit",       tostring(ZMKP_MaxHit));
-			e.self:ModifyNPCStat("min_hit",       tostring(ZMKP_MinHit));
-			failed = true;
-		end
-		if not rage_balanced then
-			ZMKP_AtkHit = ZMKP_AtkHit + 200;
-			e.self:ModifyNPCStat("atk",           tostring(ZMKP_AtkHit));
+			e.self:ModifyNPCStat("max_hit", tostring(ZMKP_MaxHit))
+			e.self:ModifyNPCStat("min_hit", tostring(ZMKP_MinHit))
 			failed = true;
 		end
 
+		if not rage_balanced then
+			ZMKP_AtkHit = ZMKP_AtkHit + 200
+			e.self:ModifyNPCStat("atk", tostring(ZMKP_AtkHit))
+			failed = true
+		end
+
 		if failed then
-			eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Your failure to balance the scales has added to Kvxe's already impressive skills.");
+			eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Your failure to balance the scales has added to Kvxe's already impressive skills.")
 		else
-			eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe's body trembles as he fails to gather power from the balanced scales.");
+			eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe's body trembles as he fails to gather power from the balanced scales.")
 		end
 
 		-- so dots will oddly still hurt him, with enough necros it is possible to skip an event if we just used HP events (live doesn't skip, probably does if you manage to kill him though)
 		-- So instead of just using straight HP events, we gotta do some checking here!
 		if math.floor(e.self:GetHPRatio()) <= (target_hp - 10) then
 				-- we'll we gotta skip an active phase basically, to next balance!
-				eq.set_timer("balance", ZMKP_Balance_Timer);
-				eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.");
-				e.self:SetOOCRegen(0);
-				target_hp = target_hp - 10;
+				eq.set_timer("balance", ZMKP_Balance_Timer)
+				eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.")
+				e.self:SetOOCRegen(0)
+				target_hp = target_hp - 10
 
-				eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-				eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-				eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-				eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+				eq.signal(298125, 2) -- NPC: #Balance_of_Speed
+				eq.signal(298126, 2) -- NPC: #Balance_of_Defense
+				eq.signal(298127, 2) -- NPC: #Balance_of_Fury
+				eq.signal(298128, 2) -- NPC: #Balance_of_Rage
 		else
-				e.self:ProcessSpecialAbilities(ZMKP_Active);
-				target_hp = target_hp - 10;
-				eq.set_next_hp_event(target_hp);
+				e.self:ProcessSpecialAbilities(ZMKP_Active)
+				target_hp = target_hp - 10
+				eq.set_next_hp_event(target_hp)
 		end
 	elseif e.timer == "wipecheck" then
 		-- Check to see if there are any Clients in the room with ZMKP
-		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 9000);
+		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 9000)
 		if not client:IsClient() then
 			-- Clean up after a wipe
-			eq.depop_all(298125);
-			eq.depop_all(298126);
-			eq.depop_all(298127);
-			eq.depop_all(298128);
+			eq.depop_all(298125)
+			eq.depop_all(298126)
+			eq.depop_all(298127)
+			eq.depop_all(298128)
 
-			eq.spawn2(298029, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()); -- NPC: Zun`Muram_Kvxe_Pirik
-			eq.depop();
+			eq.spawn2(298029, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()) -- NPC: Zun`Muram_Kvxe_Pirik
+			eq.depop()
 
-			eq.signal(298223,2); -- Unlock Doors
+			eq.signal(298223,2) -- Unlock Doors
 		end
 	end
 end
 
 function ZMKP_Hp(e)
-	if e.hp_event == 90 then
-		eq.signal(298223,1); -- Lock Doors
+	if e.hp_event == 90 or e.hp_event == 80 or e.hp_event == 70 or e.hp_event == 60 or e.hp_event == 50 or e.hp_event == 40 or e.hp_event == 30 then
+		if e.hp_event == 90 then
+			eq.signal(298223,1) -- Lock Doors
+		end
 
-		eq.set_timer("balance", ZMKP_Balance_Timer);
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.");
-		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-		e.self:SetOOCRegen(0);
-		e.self:WipeHateList();
+		eq.set_timer("balance", ZMKP_Balance_Timer)
+		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.")
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive)
+		e.self:SetOOCRegen(0)
+		e.self:WipeHateList()
 
-		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-	elseif e.hp_event == 80 then
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.");
-		eq.set_timer("balance", ZMKP_Balance_Timer);
-		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-		e.self:SetOOCRegen(0);
-		e.self:WipeHateList();
-
-		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-	elseif e.hp_event == 70 then
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.");
-		eq.set_timer("balance", ZMKP_Balance_Timer);
-		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-		e.self:SetOOCRegen(0);
-		e.self:WipeHateList();
-
-		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-	elseif e.hp_event == 60 then
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.");
-		eq.set_timer("balance", ZMKP_Balance_Timer);
-		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-		e.self:SetOOCRegen(0);
-		e.self:WipeHateList();
-
-		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-	elseif e.hp_event == 50 then
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.");
-		eq.set_timer("balance", ZMKP_Balance_Timer);
-		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-		e.self:SetOOCRegen(0);
-		e.self:WipeHateList();
-
-		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-	elseif e.hp_event == 40 then
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.");
-		eq.set_timer("balance", ZMKP_Balance_Timer);
-		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-		e.self:SetOOCRegen(0);
-		e.self:WipeHateList();
-
-		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
-	elseif e.hp_event == 30 then
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of battle meditation.");
-		eq.set_timer("balance", ZMKP_Balance_Timer);
-		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-		e.self:SetOOCRegen(0);
-		e.self:WipeHateList();
-
-		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
-		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
-		eq.signal(298127, 2); -- NPC: #Balance_of_Fury
-		eq.signal(298128, 2); -- NPC: #Balance_of_Rage
+		eq.signal(298125, 2) -- NPC: #Balance_of_Speed
+		eq.signal(298126, 2) -- NPC: #Balance_of_Defense
+		eq.signal(298127, 2) -- NPC: #Balance_of_Fury
+		eq.signal(298128, 2) -- NPC: #Balance_of_Rage
 	elseif e.hp_event == 20 then
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of seething rage as he accelerates his combat speed.");
-		ZMKP_Delay = ZMKP_Delay * 0.90;
-		e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay));
+		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, "Kvxe enters a state of seething rage as he accelerates his combat speed.")
+		ZMKP_Delay = ZMKP_Delay - 2
+		e.self:ModifyNPCStat("attack_delay",  tostring(ZMKP_Delay))
 	end
 end
 
-function ZMKP_Signal(e)
-end
-
 function ZMKP_Death(e)
-	eq.signal(298223, 298029); -- NPC: zone_status
+	eq.signal(298223, 298029) -- NPC: zone_status
 
-	eq.depop_all(298125);
-	eq.depop_all(298126);
-	eq.depop_all(298127);
-	eq.depop_all(298128);
-	eq.signal(298223,2,1000); -- Unlock Doors
+	eq.depop_all(298125)
+	eq.depop_all(298126)
+	eq.depop_all(298127)
+	eq.depop_all(298128)
+	eq.signal(298223,2,1000) -- Unlock Doors
 end
 
 function ZMKP_Spawn_Speed(e)
-	e.self:SetOOCRegen(0);
+	e.self:SetOOCRegen(0)
 end
 
 function ZMKP_Spawn_Defense(e)
-	e.self:SetOOCRegen(0);
+	e.self:SetOOCRegen(0)
 end
 
 function ZMKP_Spawn_Fury(e)
-	e.self:SetOOCRegen(0);
+	e.self:SetOOCRegen(0)
 end
 
 function ZMKP_Spawn_Rage(e)
-	e.self:SetOOCRegen(0);
+	e.self:SetOOCRegen(0)
 end
 
 function ZMKP_Signal_Balance(e)
 	if e.signal == 1 then
-		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
-		e.self:SetHP(e.self:GetMaxHP());
-		e.self:WipeHateList();
+		e.self:ProcessSpecialAbilities(ZMKP_Inactive)
+		e.self:SetHP(e.self:GetMaxHP())
+		e.self:WipeHateList()
 
 		-- lets double check
 		if e.self:GetHPRatio() <= (target_hp - 3) then
-			local id = e.self:GetNPCTypeID();
+			local id = e.self:GetNPCTypeID()
 			if id == 298125 then
-				speed_balanced = false;
+				speed_balanced = false
 			elseif id == 298126 then
-				defense_balanced = false;
+				defense_balanced = false
 			elseif id == 298127 then
-				fury_balanced = false;
+				fury_balanced = false
 			elseif id == 298128 then
-				rage_balanced = false;
+				rage_balanced = false
 			end
-			eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, e.self:GetCleanName() .. " is falling out of balance.");
+			eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, e.self:GetCleanName() .. " is falling out of balance.")
 		end
 	elseif e.signal == 2 then
-		defense_balanced = false;
-		fury_balanced = false;
-		rage_balanced = false;
-		speed_balanced = false;
+		defense_balanced = false
+		fury_balanced = false
+		rage_balanced = false
+		speed_balanced = false
 
-		eq.set_next_hp_event(target_hp + 3);
+		eq.set_next_hp_event(target_hp + 3)
 		e.self:ProcessSpecialAbilities("42,1")
-		e.self:SetHP(e.self:GetMaxHP());
-		e.self:WipeHateList();
+		e.self:SetHP(e.self:GetMaxHP())
+		e.self:WipeHateList()
 	end
 end
 
 function ZMKP_Hp_Balance(e)
 	if e.hp_event == (target_hp + 3) then
-		local id = e.self:GetNPCTypeID();
+		local id = e.self:GetNPCTypeID()
 		if id == 298125 then
-			speed_balanced = true;
+			speed_balanced = true
 		elseif id == 298126 then
-			defense_balanced = true;
+			defense_balanced = true
 		elseif id == 298127 then
-			fury_balanced = true;
+			fury_balanced = true
 		elseif id == 298128 then
-			rage_balanced = true;
+			rage_balanced = true
 		end
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, e.self:GetCleanName() .. " seems to be tipping in your favor.");
+		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, e.self:GetCleanName() .. " seems to be tipping in your favor.")
 		eq.set_next_hp_event(target_hp - 3)
 	elseif e.hp_event == (target_hp - 3) then
-		local id = e.self:GetNPCTypeID();
+		local id = e.self:GetNPCTypeID()
 		if id == 298125 then
-			speed_balanced = false;
+			speed_balanced = false
 		elseif id == 298126 then
-			defense_balanced = false;
+			defense_balanced = false
 		elseif id == 298127 then
-			fury_balanced = false;
+			fury_balanced = false
 		elseif id == 298128 then
-			rage_balanced = false;
+			rage_balanced = false
 		end
-		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, e.self:GetCleanName() .. " is falling out of balance.");
+		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, e.self:GetCleanName() .. " is falling out of balance.")
 	end
 end
 
 function event_encounter_load(e)
-	eq.register_npc_event('zmkp', Event.spawn,          298029, ZMKP_Spawn);
-	eq.register_npc_event('zmkp', Event.combat,         298029, ZMKP_Combat);
-	eq.register_npc_event('zmkp', Event.timer,          298029, ZMKP_Timer);
-	eq.register_npc_event('zmkp', Event.hp,             298029, ZMKP_Hp);
-	eq.register_npc_event('zmkp', Event.signal,         298029, ZMKP_Signal);
-	eq.register_npc_event('zmkp', Event.death_complete, 298029, ZMKP_Death);
+	eq.register_npc_event('zmkp', Event.spawn,          298029, ZMKP_Spawn)
+	eq.register_npc_event('zmkp', Event.combat,         298029, ZMKP_Combat)
+	eq.register_npc_event('zmkp', Event.timer,          298029, ZMKP_Timer)
+	eq.register_npc_event('zmkp', Event.hp,             298029, ZMKP_Hp)
+	eq.register_npc_event('zmkp', Event.death_complete, 298029, ZMKP_Death)
 
-	eq.register_npc_event('zmkp', Event.spawn,          298125, ZMKP_Spawn_Speed);
-	eq.register_npc_event('zmkp', Event.spawn,          298126, ZMKP_Spawn_Defense);
-	eq.register_npc_event('zmkp', Event.spawn,          298127, ZMKP_Spawn_Fury);
-	eq.register_npc_event('zmkp', Event.spawn,          298128, ZMKP_Spawn_Rage);
+	eq.register_npc_event('zmkp', Event.spawn,          298125, ZMKP_Spawn_Speed)
+	eq.register_npc_event('zmkp', Event.spawn,          298126, ZMKP_Spawn_Defense)
+	eq.register_npc_event('zmkp', Event.spawn,          298127, ZMKP_Spawn_Fury)
+	eq.register_npc_event('zmkp', Event.spawn,          298128, ZMKP_Spawn_Rage)
 
-	eq.register_npc_event('zmkp', Event.signal,         298125, ZMKP_Signal_Balance);
-	eq.register_npc_event('zmkp', Event.signal,         298126, ZMKP_Signal_Balance);
-	eq.register_npc_event('zmkp', Event.signal,         298127, ZMKP_Signal_Balance);
-	eq.register_npc_event('zmkp', Event.signal,         298128, ZMKP_Signal_Balance);
+	eq.register_npc_event('zmkp', Event.signal,         298125, ZMKP_Signal_Balance)
+	eq.register_npc_event('zmkp', Event.signal,         298126, ZMKP_Signal_Balance)
+	eq.register_npc_event('zmkp', Event.signal,         298127, ZMKP_Signal_Balance)
+	eq.register_npc_event('zmkp', Event.signal,         298128, ZMKP_Signal_Balance)
 
-	eq.register_npc_event('zmkp', Event.hp,             298125, ZMKP_Hp_Balance);
-	eq.register_npc_event('zmkp', Event.hp,             298126, ZMKP_Hp_Balance);
-	eq.register_npc_event('zmkp', Event.hp,             298127, ZMKP_Hp_Balance);
-	eq.register_npc_event('zmkp', Event.hp,             298128, ZMKP_Hp_Balance);
+	eq.register_npc_event('zmkp', Event.hp,             298125, ZMKP_Hp_Balance)
+	eq.register_npc_event('zmkp', Event.hp,             298126, ZMKP_Hp_Balance)
+	eq.register_npc_event('zmkp', Event.hp,             298127, ZMKP_Hp_Balance)
+	eq.register_npc_event('zmkp', Event.hp,             298128, ZMKP_Hp_Balance)
 end

--- a/tacvi/encounters/zmyv.lua
+++ b/tacvi/encounters/zmyv.lua
@@ -1,96 +1,112 @@
 function ZMYV_Spawn(e)
-	eq.signal(298223,2); -- Unlock Doors
-	eq.set_next_hp_event(90);
-	e.self:ModSkillDmgTaken(1, 5); -- 1h slashing
-	e.self:ModSkillDmgTaken(3, 5); -- 2h slashing
+	eq.signal(298223,2) -- Unlock Doors
+	eq.set_next_hp_event(90)
+	e.self:ModSkillDmgTaken(1, 5) -- 1h slashing
+	e.self:ModSkillDmgTaken(3, 5) -- 2h slashing
 end
 
 function ZMYV_Combat(e)
 	if e.joined then
-		e.self:Say("The weak willed and the idle will serve my cause.");
-		eq.set_timer("allure", 90 * 1000);
+		e.self:Say("The weak willed and the idle will serve my cause.")
+		eq.set_timer("allure", 90 * 1000)
 	else
-		eq.set_timer("wipecheck", 1 * 1000);
-		eq.stop_timer("check");
-		eq.stop_timer("allure");
+		eq.set_timer("wipecheck", 1 * 1000)
+		eq.stop_timer("check")
+		eq.stop_timer("allure")
 	end
 end
 
 function ZMYV_Timer(e)
 	if e.timer == "wipecheck" then
-		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 8000);
+		local client = eq.get_entity_list():GetRandomClient(e.self:GetX(), e.self:GetY(), e.self:GetZ(), 8000)
 		if not client:IsClient() then
 			-- Wipe Mechanics
-			eq.signal(298223,2); -- Unlock Doors
-			eq.spawn2(298023, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()); -- NPC: Zun`Muram_Yihst_Vor
-			eq.stop_timer("memblur");
-			eq.depop();
+			eq.signal(298223,2) -- Unlock Doors
+			eq.spawn2(298023, 0, 0, e.self:GetX(), e.self:GetY(), e.self:GetZ(), e.self:GetHeading()) -- NPC: Zun`Muram_Yihst_Vor
+			eq.stop_timer("memblur")
+			eq.depop()
 		end
-	elseif e.timer == "allure" then 
-		for i=1,6 do
-			local target = e.self:GetHateRandom();
-			if target:IsPet() then
-				target = target:GetOwner();
-			end
-
-			if target.valid and not target:FindBuff(4441) then
-				e.self:SpellFinished(4441, target); -- Spell: Allure of Hatred
-			end
-		end
-		e.self:WipeHateList();
+	elseif e.timer == "allure" then
+		eq.signal(298000,1)
+		eq.signal(298001,1)
+		eq.signal(298003,1)
+		eq.signal(298004,1)
+		eq.signal(298005,1)
+		eq.signal(298006,1)
+		e.self:WipeHateList()
 	elseif e.timer == "check" then
-		local instance_id = eq.get_zone_instance_id();
+		local instance_id = eq.get_zone_instance_id()
 		e.self:ForeachHateList(
 			function(ent, hate, damage, frenzy)
-				if(ent:IsClient() and ent:GetX() < 295 or ent:GetX() > 447 or ent:GetY() < -560 or ent:GetY() > -418) then
-					local currclient=ent:CastToClient();
-					--e.self:Shout("You will not evade me " .. currclient:GetName())
-					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0); -- Zone: tacvi
-					currclient:Message(MT.Magenta,"Zun`Muram Yihst Vor says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.");
+				if (ent:IsClient() and ent:GetX() < 295 or ent:GetX() > 447 or ent:GetY() < -560 or ent:GetY() > -418) then
+					local currclient=ent:CastToClient()
+					currclient:MovePCInstance(298,instance_id, e.self:GetX(),e.self:GetY(),e.self:GetZ(),0) -- Zone: tacvi
+					currclient:Message(MT.Magenta,"Zun`Muram Yihst Vor says, 'You dare enter my chambers and then try to leave? Your punishment will be quite severe.")
 				end
 			end
-		);
+		)
 	end
 end
 
 function ZMYV_Hp(e)
 	if e.hp_event == 90 then
-		eq.signal(298223,1); -- Lock Doors
-		eq.set_timer("check", 1 * 1000); -- set scorpion timer
-		eq.set_next_hp_event(75);
-		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor says, 'Is this is the best you can do? Come now, show me your true strength and I will show you mine.' ");
-		e.self:ModifyNPCStat("min_hit", "1899");
-		e.self:ModifyNPCStat("max_hit", "5176");
+		eq.signal(298223,1) -- Lock Doors
+		eq.set_timer("check", 1 * 1000) -- set scorpion timer
+		eq.set_next_hp_event(75)
+		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor says, 'Is this is the best you can do? Come now, show me your true strength and I will show you mine.' ")
+		e.self:ModifyNPCStat("min_hit", "1899")
+		e.self:ModifyNPCStat("max_hit", "5176")
 	elseif e.hp_event == 75 then
-		eq.set_next_hp_event(50);
-		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor says, 'To think I was actually worried you might be worthy foes.");
-		e.self:ModifyNPCStat("min_hit", "2124");
-		e.self:ModifyNPCStat("max_hit", "5401");
+		eq.set_next_hp_event(50)
+		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor says, 'To think I was actually worried you might be worthy foes.")
+		e.self:ModifyNPCStat("min_hit", "2124")
+		e.self:ModifyNPCStat("max_hit", "5401")
 	elseif e.hp_event == 50 then
-		eq.set_next_hp_event(20);
-		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor says, 'Ahh, sweet pain. It is such an intoxicating feeling. I thank you for the pleasure. Now let me return the favor.");
-		e.self:ModifyNPCStat("min_hit", "2254");
-		e.self:ModifyNPCStat("max_hit", "5591");
+		eq.set_next_hp_event(20)
+		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor says, 'Ahh, sweet pain. It is such an intoxicating feeling. I thank you for the pleasure. Now let me return the favor.")
+		e.self:ModifyNPCStat("min_hit", "2254")
+		e.self:ModifyNPCStat("max_hit", "5591")
 	elseif e.hp_event == 20 then
-		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor's body bulges with strength as he enters a blind rage.");
-		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1);
-		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 50); -- 50% Mitigation
-		e.self:SetSpecialAbility(SpecialAbility.rampage, 0);
-		e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
-		e.self:ModifyNPCStat("min_hit", "2573");
-		e.self:ModifyNPCStat("max_hit", "5850");
+		eq.zone_emote(MT.Yellow,"Zun`Muram Yihst Vor's body bulges with strength as he enters a blind rage.")
+		e.self:SetSpecialAbility(SpecialAbility.area_rampage, 1)
+		e.self:SetSpecialAbilityParam(SpecialAbility.area_rampage, 2, 50) -- 50% Mitigation
+		e.self:SetSpecialAbility(SpecialAbility.rampage, 0)
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 0)
+		e.self:ModifyNPCStat("min_hit", "2573")
+		e.self:ModifyNPCStat("max_hit", "5850")
+	end
+end
+
+function Charm_Signal(e)
+	local target = eq.get_entity_list():GetRandomClient(366,-488,-0.375,5000)
+	if target.valid and not target:FindBuff(4441) then
+		e.self:SpellFinished(4441, target) -- Spell: Allure of Hatred
 	end
 end
 
 function ZMYV_Death(e)
-	eq.signal(298223,298023); -- NPC: zone_status
-	eq.signal(298223,2,1000); -- Unlock Doors
+	eq.signal(298223,298023) -- NPC: zone_status
+	eq.signal(298223,2,1000) -- Unlock Doors
+	eq.depop(298000)
+	eq.depop(298001)
+	eq.depop(298003)
+	eq.depop(298004)
+	eq.depop(298005)
+	eq.depop(298006)
 end
 
 function event_encounter_load(e)
-	eq.register_npc_event('zmyv', Event.spawn,          298023, ZMYV_Spawn); 
-	eq.register_npc_event('zmyv', Event.combat,         298023, ZMYV_Combat); 
-	eq.register_npc_event('zmyv', Event.timer,          298023, ZMYV_Timer); 
-	eq.register_npc_event('zmyv', Event.hp,             298023, ZMYV_Hp); 
-	eq.register_npc_event('zmyv', Event.death_complete, 298023, ZMYV_Death); 
+	eq.register_npc_event('zmyv', Event.spawn,          298023, ZMYV_Spawn)
+	eq.register_npc_event('zmyv', Event.combat,         298023, ZMYV_Combat)
+	eq.register_npc_event('zmyv', Event.timer,          298023, ZMYV_Timer)
+	eq.register_npc_event('zmyv', Event.hp,             298023, ZMYV_Hp)
+	eq.register_npc_event('zmyv', Event.death_complete, 298023, ZMYV_Death)
+
+	-- Charm NPCs
+	eq.register_npc_event('zmyv', Event.signal,			298000, Charm_Signal)
+	eq.register_npc_event('zmyv', Event.signal,			298001, Charm_Signal)
+	eq.register_npc_event('zmyv', Event.signal,			298003, Charm_Signal)
+	eq.register_npc_event('zmyv', Event.signal,			298004, Charm_Signal)
+	eq.register_npc_event('zmyv', Event.signal,			298005, Charm_Signal)
+	eq.register_npc_event('zmyv', Event.signal,			298006, Charm_Signal)
 end

--- a/tacvi/zone_status.lua
+++ b/tacvi/zone_status.lua
@@ -23,9 +23,8 @@
 --]]
 --
 
-local instance_id = 0;
-local charid_list;
-local entity_list;
+local instance_id = 0
+local entity_list
 local Tacvi_Lockouts = {}
 
 -- Events
@@ -38,39 +37,69 @@ local ZMMD_EVENT	= 'Zun`Muram Mordl Delt'
 local ZMYV_EVENT	= 'Zun`Muram Yihst Vor'
 local TMCV_EVENT	= 'Tunat`Muram Cuu Vauax'
 
+-- Remains
+
+local REMAINS_RASHERE  = 'Rashere`s Remains'
+local REMAINS_KAIKACHI = 'Kaikachi`s Remains'
+local REMAINS_LYNDROH  = 'Lyndroh`s Remains'
+local REMAINS_SILIUS   = 'Silius`s Remains'
+local REMAINS_MADDOC   = 'Maddoc`s Remains'
+local REMAINS_VAHLARA  = 'Vahlara`s Remains'
+local REMAINS_VALTRON  = 'Valtron`s Remains'
+local REMAINS_PRATHUN  = 'Prathun`s Remains'
+local REMAINS_RYTAN    = 'Rytan`s Remains'
+local REMAINS_XENAIDA  = 'Xenaida`s Remains'
+local REMAINS_WIJDAN   = 'Wijdan`s Remains'
+local REMAINS_ABSOR    = 'Absor`s Remains'
+local REMAINS_FRIZZNIK = 'Frizznik`s Remains'
+local REMAINS_ZAJEER   = 'Zajeer`s Remains'
+
 
 function setup_event() -- 4.5 Days
 	Tacvi_Lockouts = {
-		[298039] = {PXK_EVENT,	eq.seconds('108h'), Spawn_PXK},
-		[298201] = {PKK_EVENT,	eq.seconds('108h'), Spawn_PKK},
-		[298032] = {PRT_EVENT,	eq.seconds('108h'), Spawn_PRT},
-		[298029] = {ZMKP_EVENT,	eq.seconds('108h'), Spawn_ZMKP},
-		[298018] = {ZMSB_EVENT,	eq.seconds('108h'), Spawn_ZMSB},
-		[298020] = {ZMMD_EVENT,	eq.seconds('108h'), Spawn_ZMMD},
-		[298023] = {ZMYV_EVENT,	eq.seconds('108h'), Spawn_ZMYV},
-		[298055] = {TMCV_EVENT,	eq.seconds('108h'), Spawn_TMCV}
+		[298039] = {PXK_EVENT,        eq.seconds('108h'), Spawn_PXK},
+		[298201] = {PKK_EVENT,        eq.seconds('108h'), Spawn_PKK},
+		[298032] = {PRT_EVENT,        eq.seconds('108h'), Spawn_PRT},
+		[298029] = {ZMKP_EVENT,       eq.seconds('108h'), Spawn_ZMKP},
+		[298018] = {ZMSB_EVENT,       eq.seconds('108h'), Spawn_ZMSB},
+		[298020] = {ZMMD_EVENT,       eq.seconds('108h'), Spawn_ZMMD},
+		[298023] = {ZMYV_EVENT,       eq.seconds('108h'), Spawn_ZMYV},
+		[298055] = {TMCV_EVENT,       eq.seconds('108h'), Spawn_TMCV},
+		[3]      = {REMAINS_LYNDROH,  eq.seconds('108h'), Spawn_REMAINS3},
+		[4]      = {REMAINS_SILIUS,   eq.seconds('108h'), Spawn_REMAINS4},
+		[5]      = {REMAINS_MADDOC,   eq.seconds('108h'), Spawn_REMAINS5},
+		[6]      = {REMAINS_VAHLARA,  eq.seconds('108h'), Spawn_REMAINS6},
+		[7]      = {REMAINS_VALTRON,  eq.seconds('108h'), Spawn_REMAINS7},
+		[8]      = {REMAINS_PRATHUN,  eq.seconds('108h'), Spawn_REMAINS8},
+		[9]      = {REMAINS_RYTAN,    eq.seconds('108h'), Spawn_REMAINS9},
+		[10]     = {REMAINS_XENAIDA,  eq.seconds('108h'), Spawn_REMAINS10},
+		[11]     = {REMAINS_WIJDAN,   eq.seconds('108h'), Spawn_REMAINS11},
+		[12]     = {REMAINS_ABSOR,    eq.seconds('108h'), Spawn_REMAINS12},
+		[13]     = {REMAINS_FRIZZNIK, eq.seconds('108h'), Spawn_REMAINS13},
+		[14]     = {REMAINS_ZAJEER,   eq.seconds('108h'), Spawn_REMAINS14},
+		[15]     = {REMAINS_RASHERE,  eq.seconds('108h'), Spawn_REMAINS1},
+		[16]     = {REMAINS_KAIKACHI, eq.seconds('108h'), Spawn_REMAINS2}
 	}
 end
 
 function event_spawn(e)
-	instance_id = eq.get_zone_instance_id();
-	charid_list = eq.get_characters_in_instance(instance_id);
-	entity_list = eq.get_entity_list();
-	local zone_id = eq.get_zone_id();
-	local expedition = eq.get_expedition_by_zone_instance(zone_id,instance_id);
+	instance_id      = eq.get_zone_instance_id()
+	entity_list      = eq.get_entity_list()
+	local zone_id    = eq.get_zone_id()
+	local expedition = eq.get_expedition_by_zone_instance(zone_id,instance_id)
 
 	if expedition.valid then
-		setup_event();
+		setup_event()
 	end
 
 	-- Door at zone in; Talking to Sensnil will unlock
-	Door_Lock(18);
+	Door_Lock(18)
 
 	-- Doors to TMCV
-	Door_Lock(10);
-	Door_Lock(11);
-	Door_Lock(14);
-	Door_Lock(19);
+	Door_Lock(10)
+	Door_Lock(11)
+	Door_Lock(14)
+	Door_Lock(19)
 
 	for k,v in pairs(Tacvi_Lockouts) do
 		if v[3] and not expedition:HasLockout(v[1]) then
@@ -80,52 +109,45 @@ function event_spawn(e)
 end
 
 function Spawn_PXK()
-	eq.spawn2(298039, 0, 0, 151.00, -162.00, -0.375, 386); -- NPC: Pixtt_Xxeric_Kex
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 37.0, -165.0, -2.75, 392); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	-- Zajee's remains
-	eq.spawn2(298038, 0, 0, 12, -106, -6.03, 264):SetAppearance(3); -- NPC: #Zajeer`s_remains
+	eq.spawn2(298039, 0, 0, 151.00, -162.00, -0.375, 386) -- NPC: Pixtt_Xxeric_Kex
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 37.0, -165.0, -2.75, 392) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
 end
 
 function Spawn_PKK()
-	eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378); -- NPC: Pixtt_Kretv_Krakxt
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 76.0, 246.0, -2.75, 388); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	-- Frizznik's remains
-	eq.spawn2(298036, 0, 0, 49, 251, -6.03, 40):SetAppearance(3); -- NPC: #Frizznik`s_Remains
+	eq.spawn2(298201, 0, 0, 161.0, 242.0, -4.125, 378) -- NPC: Pixtt_Kretv_Krakxt
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 76.0, 246.0, -2.75, 388) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
 end
 
 function Spawn_PRT()
-	eq.spawn2(298032, 0, 0, 202.0, -586.0, -4.125, 380); -- NPC: Pixtt_Riel_Tavas
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 83.0, -586.0, -2.75, 378); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	-- Absor's Remains
-	eq.spawn2(298037, 0, 0, 66, -448, -6.03, 208):SetAppearance(3); -- NPC: #Absor`s_Remains
+	eq.spawn2(298032, 0, 0, 202.0, -586.0, -4.125, 380) -- NPC: Pixtt_Riel_Tavas
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 83.0, -586.0, -2.75, 378) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
 end
 
 function Spawn_ZMKP()
-	eq.spawn2(298029, 0, 0, 373.0, -686.0, -0.375, 352); -- NPC: Zun`Muram_Kvxe_Pirik
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 276.0, -685.0, -2.75, 366); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	-- Wijdan's Remains
-	eq.spawn2(298030, 0, 0, 211, -683, -6.03, 496):SetAppearance(3); -- NPC: #Wijdan`s_Remains
+	eq.spawn2(298029, 0, 0, 373.0, -686.0, -0.375, 352) -- NPC: Zun`Muram_Kvxe_Pirik
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 276.0, -685.0, -2.75, 366) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
 end
 
 function Spawn_ZMSB()
-	eq.spawn2(298018, 0, 0, 366.0, 342.0, -0.375, 360); -- NPC: Zun`Muram_Shaldn_Boc
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 274.0, 345.0, -2.75, 364); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	-- Xenaida's remains
-	eq.spawn2(298033, 0, 0, 230, 335, -6.03, 296):SetAppearance(3); -- NPC: #Xenaida`s_Remains
+	eq.spawn2(298018, 0, 0, 366.0, 342.0, -0.375, 360) -- NPC: Zun`Muram_Shaldn_Boc
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 274.0, 345.0, -2.75, 364) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
 end
 
 function Spawn_ZMMD()
-	eq.spawn2(298020, 0, 0, 369.0, 144.0, -0.375, 352); -- NPC: Zun`Muram_Mordl_Delt
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 270.0, 146.0, -2.75, 370); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	-- Rytan's remains
-	eq.spawn2(298034, 0, 0, 229, 149, -6.03, 504):SetAppearance(3); -- NPC: #Rytan`s_Remains
+	eq.spawn2(298020, 0, 0, 369.0, 144.0, -0.375, 352) -- NPC: Zun`Muram_Mordl_Delt
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 270.0, 146.0, -2.75, 370) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
 end
 
 function Spawn_ZMYV()
-	eq.spawn2(298023, 0, 0, 366.0, -488.0, -0.375, 352); -- NPC: Zun`Muram_Yihst_Vor
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 272.0, -487.0, -2.75, 354); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	-- Prathun's Remains
-	eq.spawn2(298022, 0, 0, 197, -493, -6.77, 121.2):SetAppearance(3); -- NPC: #Prathun`s_Remains
+	local x,y,z,h = 366, -488, -0.375, 352
+	eq.spawn2(298023, 0, 0, x, y, z, h)		        -- NPC: Zun`Muram_Yihst_Vor
+	eq.spawn2(298000, 0, 0, x + 30, y + 30, z, h)	-- NPC: _
+	eq.spawn2(298001, 0, 0, x + 30, y - 30, z, h)	-- NPC: _
+	eq.spawn2(298003, 0, 0, x - 30, y + 30, z, h)	-- NPC: _
+	eq.spawn2(298004, 0, 0, x - 30, y - 30, z, h)	-- NPC: _
+	eq.spawn2(298005, 0, 0, x + 30, y, z, h)	    -- NPC: _
+	eq.spawn2(298006, 0, 0, x - 30, y, z, h)	    -- NPC: _
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 272.0, -487.0, -2.75, 354) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
 end
 
 function Spawn_TMCV()
@@ -141,107 +163,91 @@ function Spawn_TMCV()
 	--  535 72 23.48 236
 	--  601 -362 21.23 134.5
 	--  538 -416 15.23 129.1
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 602.0, 16.0, 25.125, 4); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 535.0, 72.0, 21.125, 14); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 601.0, -362.0, 25.125, 258); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
-	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 538.0, -416.0, 19.125, 258); -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 602.0, 16.0, 25.125, 4) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 535.0, 72.0, 21.125, 14) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 601.0, -362.0, 25.125, 258) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
+	eq.spawn2(eq.ChooseRandom(298015,298016,298021), 0, 0, 538.0, -416.0, 19.125, 258) -- NPC(s): an_elite_mastruq_berserker (298015), an_elite_mastruq_crusher (298016), an_elite_mastruq_destroyer (298021)
 
-	eq.spawn2(298014, 0, 0, 462, -171, 32, 128.2); -- NPC: #Tunat`Muram_Cuu_Vauax
-
-	-- Rashere's remains
-	eq.spawn2(298031, 0, 0, 506, 147, -6.03, 480):SetAppearance(3); -- NPC: #Rashere`s_Remains
-	-- Kaikachi`s remains
-	eq.spawn2(298017, 0, 0, 592, 313, -6.03, 440):SetAppearance(3); -- NPC: #Kaikachi`s_Remains
-	-- Lyndroh's remains
-	eq.spawn2(298010, 0, 0, 320, -144, 21.85, 96):SetAppearance(3); -- NPC: #Lyndroh`s_Remains
-	-- Silius's remains
-	eq.spawn2(298009, 0, 0, 322, -199, 21.85, 168):SetAppearance(3); -- NPC: #Silius`_Remains
-	-- Maddoc's remains
-	eq.spawn2(298011, 0, 0, 483, -171, 25.85, 496):SetAppearance(3); -- NPC: #Maddoc`s_Remains
-	-- Vahlara's remains
-	eq.spawn2(298024, 0, 0, 600, -588, -6.03, 0.0):SetAppearance(3); -- NPC: #Vahlara`s_Remains
-	-- Valtron's remains
-	eq.spawn2(298019, 0, 0, 494, -494, -6.125, 312):SetAppearance(3); -- NPC: #Valtron`s_Remains
-
+	eq.spawn2(298014, 0, 0, 462, -171, 32, 128.2) -- NPC: #Tunat`Muram_Cuu_Vauax
 end
 
 function Door_Lock(door_id)
-	local door = 0;
-	door = entity_list:FindDoor(door_id);
-	if (door ~= nil) then
-		door:SetLockPick(-1);
+	local door = 0
+	door = entity_list:FindDoor(door_id)
+	if door ~= nil then
+		door:SetLockPick(-1)
 	end
 end
 
 function Door_Unlock(door_id)
 	local door = 0;
-	door = entity_list:FindDoor(door_id);
-	if (door ~= nil) then
-		door:SetLockPick(0);
+	door = entity_list:FindDoor(door_id)
+	if door ~= nil then
+		door:SetLockPick(0)
 	end
 end
 
 function event_signal(e)
 	if e.signal == 1 then -- Lock all doors
 		for i=2,23 do
-			eq.get_entity_list():FindDoor(i):SetLockPick(-1);
+			eq.get_entity_list():FindDoor(i):SetLockPick(-1)
 		end
 	elseif e.signal == 2 then -- Unlock all cleared doors
 		local expedition = eq.get_expedition()
 		if expedition.valid then
-			-- Unlock main door and PXK door always
-			eq.get_entity_list():FindDoor(18):SetLockPick(0); -- Main Entrance
-			eq.get_entity_list():FindDoor(2):SetLockPick(0); -- PXK Entrance
+			-- Unlock main door and PXK door always.
+			Door_Unlock(18) -- Main Entrance
+			Door_Unlock(2)  -- PXK Entrance
 
 			if expedition:HasLockout(PXK_EVENT) then -- unlock PXK North/South and PKK/PRT Entrance
-				eq.get_entity_list():FindDoor(3):SetLockPick(0); -- PKK South Exit
-				eq.get_entity_list():FindDoor(4):SetLockPick(0); -- PXK North Exit
-				eq.get_entity_list():FindDoor(5):SetLockPick(0); -- PKK Entrance
-				eq.get_entity_list():FindDoor(23):SetLockPick(0); -- PRT Entrance
+				Door_Unlock(3)  -- PXK South Exit
+				Door_Unlock(4)  -- PXK North Exit
+				Door_Unlock(5)  -- PKK Entrance
+				Door_Unlock(23) -- PRT Entrance
 			end
 
 			if expedition:HasLockout(PKK_EVENT) then -- unlock PKK North/South and ZMSB/ZMMD Entrance
-				eq.get_entity_list():FindDoor(6):SetLockPick(0); -- PKK South Exit
-				eq.get_entity_list():FindDoor(7):SetLockPick(0); -- PKK North Exit
-				eq.get_entity_list():FindDoor(8):SetLockPick(0); -- ZMSB Entrance
-				eq.get_entity_list():FindDoor(13):SetLockPick(0); -- ZMMD Entrance
+				Door_Unlock(6)  -- PKK South Exit
+				Door_Unlock(7)  -- PKK North Exit
+				Door_Unlock(8)  -- ZMSB Entrance
+				Door_Unlock(13) -- ZMMD Entrance
 			end
 
 			if expedition:HasLockout(ZMSB_EVENT) then -- unlock ZMSB Exit and ZMSB Tunat Entrance
-				eq.get_entity_list():FindDoor(9):SetLockPick(0); -- ZMSB Exit
-				eq.get_entity_list():FindDoor(10):SetLockPick(0); -- ZMSB Tunat
+				Door_Unlock(9)  -- ZMSB Exit
+				Door_Unlock(10) -- ZMSB Tunat
 			end
 
 			if expedition:HasLockout(ZMMD_EVENT) then -- unlock ZMMD Exit and ZMMD Tunat Entrance
-				eq.get_entity_list():FindDoor(12):SetLockPick(0); -- ZMMD Exit
-				eq.get_entity_list():FindDoor(11):SetLockPick(0); -- ZMMD Tunat
+				Door_Unlock(12) -- ZMMD Exit
+				Door_Unlock(11) -- ZMMD Tunat
 			end
 
 			if expedition:HasLockout(PRT_EVENT) then -- unlock PRT North/South and ZMYV/ZMKP Entrance
-				eq.get_entity_list():FindDoor(17):SetLockPick(0); -- PRT South Exit
-				eq.get_entity_list():FindDoor(22):SetLockPick(0); -- PRT North Exit
-				eq.get_entity_list():FindDoor(21):SetLockPick(0); -- ZMYV Entrance
-				eq.get_entity_list():FindDoor(16):SetLockPick(0); -- ZMKP Entrance
+				Door_Unlock(17) -- PRT South Exit
+				Door_Unlock(22) -- PRT North Exit
+				Door_Unlock(21) -- ZMYV Entrance
+				Door_Unlock(16) -- ZMKP Entrance
 			end
 
 			if expedition:HasLockout(ZMYV_EVENT) then -- unlock ZMYV Exit and ZMYV Tunat Entrance
-				eq.get_entity_list():FindDoor(20):SetLockPick(0); -- ZMYV Exit
-				eq.get_entity_list():FindDoor(19):SetLockPick(0); -- ZMYV Tunat
+				Door_Unlock(20) -- ZMYV Exit
+				Door_Unlock(19) -- ZMYV Tunat
 			end
 
 			if expedition:HasLockout(ZMKP_EVENT) then -- unlock ZMKP Exit and ZMKP Tunat Entrance
-				eq.get_entity_list():FindDoor(15):SetLockPick(0); -- ZMKP Exit
-				eq.get_entity_list():FindDoor(14):SetLockPick(0); -- ZMKP Tunat
+				Door_Unlock(15) -- ZMKP Exit
+				Door_Unlock(14) -- ZMKP Tunat
 			end
 		end
-	elseif ( Tacvi_Lockouts[e.signal] ~= nil ) then
-		AddLockout( Tacvi_Lockouts[e.signal] );
+	elseif Tacvi_Lockouts[e.signal] ~= nil then
+		AddLockout(Tacvi_Lockouts[e.signal])
 	end
 end
 
 function AddLockout(lockout)
-	local lockout_name = lockout[1];
-	local lockout_duration = lockout[2];
+	local lockout_name = lockout[1]
+	local lockout_duration = lockout[2]
 
 	local expedition = eq.get_expedition()
 	if expedition.valid then
@@ -251,4 +257,60 @@ function AddLockout(lockout)
 		-- 3) all clients currently inside the dz instance in case members were removed but haven't been teleported out yet
 		expedition:AddLockout(lockout_name, lockout_duration)
 	end
+end
+
+function Spawn_REMAINS1(e)
+	eq.spawn2(298031, 0, 0, 506, 147, -6.03, 480):SetAppearance(3) -- NPC: #Rashere`s_Remains
+end
+
+function Spawn_REMAINS2(e)
+	eq.spawn2(298017, 0, 0, 592, 313, -6.03, 440):SetAppearance(3) -- NPC: #Kaikachi`s_Remains
+end
+
+function Spawn_REMAINS3(e)
+	eq.spawn2(298010, 0, 0, 320, -144, 21.85, 96):SetAppearance(3) -- NPC: #Lyndroh`s_Remains
+end
+
+function Spawn_REMAINS4(e)
+	eq.spawn2(298009, 0, 0, 322, -199, 21.85, 168):SetAppearance(3) -- NPC: #Silius`_Remains
+end
+
+function Spawn_REMAINS5(e)
+	eq.spawn2(298011, 0, 0, 483, -171, 25.85, 496):SetAppearance(3) -- NPC: #Maddoc`s_Remains
+end
+
+function Spawn_REMAINS6(e)
+	eq.spawn2(298024, 0, 0, 600, -588, -6.03, 0.0):SetAppearance(3) -- NPC: #Vahlara`s_Remains
+end
+
+function Spawn_REMAINS7(e)
+	eq.spawn2(298019, 0, 0, 494, -494, -6.125, 312):SetAppearance(3) -- NPC: #Valtron`s_Remains
+end
+
+function Spawn_REMAINS8(e)
+	eq.spawn2(298022, 0, 0, 197, -493, -6.77, 121.2):SetAppearance(3) -- NPC: #Prathun`s_Remains
+end
+
+function Spawn_REMAINS9(e)
+	eq.spawn2(298034, 0, 0, 229, 149, -6.03, 504):SetAppearance(3) -- NPC: #Rytan`s_Remains
+end
+
+function Spawn_REMAINS10(e)
+	eq.spawn2(298033, 0, 0, 230, 335, -6.03, 296):SetAppearance(3) -- NPC: #Xenaida`s_Remains
+end
+
+function Spawn_REMAINS11(e)
+	eq.spawn2(298030, 0, 0, 211, -683, -6.03, 496):SetAppearance(3) -- NPC: #Wijdan`s_Remains
+end
+
+function Spawn_REMAINS12(e)
+	eq.spawn2(298037, 0, 0, 66, -448, -6.03, 208):SetAppearance(3) -- NPC: #Absor`s_Remains
+end
+
+function Spawn_REMAINS13(e)
+	eq.spawn2(298036, 0, 0, 49, 251, -6.03, 40):SetAppearance(3) -- NPC: #Frizznik`s_Remains
+end
+
+function Spawn_REMAINS14(e)
+	eq.spawn2(298038, 0, 0, 12, -106, -6.03, 264):SetAppearance(3) -- NPC: #Zajeer`s_remains
 end


### PR DESCRIPTION
- General Script syntax cleanup
- Address issue with PRT not resetting flurry or attack speed
- Addressing PXK spawning one too many waves of dogs per live parsing.
- Solve EQEmu wide bug with charm. NPC's on live are allowed to charm more than one PC, but EQEmu treats NPC's like PCs and only allows 1 charm per entity. To work around this limitation, ZMYV has 6 invisible npc's that will provide the charm services as there should be 6 charms that go out per wave.
- Simplified the logic for ZMKP however note, there is still a bug where if a raid completely kills one of the balance mobs, it will be considered a fail for the rest of the encounter. AKA - Do not kill the balance mob unless you want Hard Mode.
- Addressed an exploit with the 14 corpses quest where you could drop DZ and continue to farm a specific corpse over and over as they were tied to the boss. Live uses a hidden flag to track this, I made it visible as a lockout.