### PR TITLE
Reset tavas flurry and delay after wipe

### DIFF
--- a/tacvi/encounters/prt.lua
+++ b/tacvi/encounters/prt.lua
@@ -149,6 +149,9 @@ function PRT_Timer(e)
 		golems_spawn = false;
 		construct = 0;		
 		eq.signal(298223,2); -- Unlock Doors
+		e.self:SetSpecialAbility(SpecialAbility.flurry, 0);
+		e.self:SetSpecialAbilityParam(SpecialAbility.flurry, 0, 0)
+		e.self:ModifyNPCStat("attack_delay","16");
 	elseif (e.timer == "check") then
 		local instance_id = eq.get_zone_instance_id();
 		e.self:ForeachHateList(


### PR DESCRIPTION
Tacvi Tavas encounter does not reset after wipe.  This will reset the encounter with the proper flurry/melee delay values.

100% Health
<img width="556" height="298" alt="image" src="https://github.com/user-attachments/assets/1fab966f-f9e3-4f03-8d68-ad338e41b74a" />
<img width="690" height="1159" alt="image" src="https://github.com/user-attachments/assets/2c08d149-f2e3-406c-9a7e-2435700d3eca" />


10% Health
<img width="546" height="420" alt="image" src="https://github.com/user-attachments/assets/686c9aac-d9fb-4dd7-a2f3-4790dcf3335c" />
<img width="688" height="1135" alt="image" src="https://github.com/user-attachments/assets/e7f9a634-eab5-4279-9352-f6b119b671a4" />


After wipe:
<img width="582" height="301" alt="image" src="https://github.com/user-attachments/assets/444bb6c0-d8ba-43a8-bb9d-680f1ed60762" />
<img width="693" height="1143" alt="image" src="https://github.com/user-attachments/assets/8781fe89-9610-4077-9507-878054169977" />

